### PR TITLE
Annotations, test stubs, and minor cleanup

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+// Connection is the commonality of LocalConnection and RemoteConnection.
+// TODO(pb): does this need to be exported?
 type Connection interface {
 	Local() *Peer
 	Remote() *Peer
@@ -19,16 +21,31 @@ type Connection interface {
 	Log(args ...interface{})
 }
 
+// ConnectionTieBreak describes the outcome of a tiebreaking contest between
+// two connections.
+// TODO(pb): does this need to be exported?
 type ConnectionTieBreak int
 
 const (
+	// TieBreakWon indicates the candidate has won the tiebreak.
+	// TODO(pb): does this need to be exported?
 	TieBreakWon ConnectionTieBreak = iota
+
+	// TieBreakLost indicates the candidate has lost the tiebreak.
+	// TODO(pb): does this need to be exported?
 	TieBreakLost
+
+	// TieBreakTied indicates the tiebreaking contest had no winner.
+	// TODO(pb): does this need to be exported?
 	TieBreakTied
 )
 
+// TODO(pb): does this need to be exported?
 var ErrConnectToSelf = fmt.Errorf("Cannot connect to ourself")
 
+// RemoteConnection is a local representation of the remote side of a
+// connection. It has limited capabilities compared to LocalConnection.
+// TODO(pb): does this need to be exported?
 type RemoteConnection struct {
 	local         *Peer
 	remote        *Peer
@@ -37,6 +54,9 @@ type RemoteConnection struct {
 	established   bool
 }
 
+// LocalConnection is the local side of a connection. It implements
+// ProtocolSender, and manages per-channel GossipSenders.
+// TODO(pb): does this need to be exported?
 type LocalConnection struct {
 	sync.RWMutex
 	RemoteConnection
@@ -56,12 +76,19 @@ type LocalConnection struct {
 	gossipSenders   *GossipSenders
 }
 
+// GossipConnection describes something that can yield multiple GossipSenders.
+// TODO(pb): does this need to be exported?
 type GossipConnection interface {
 	GossipSenders() *GossipSenders
 }
 
+// ConnectionAction is the actor closure used by LocalConnection. If an action
+// returns an error, it will terminate the actor loop, which terminates the
+// connection in turn.
+// TODO(pb): does this need to be exported?
 type ConnectionAction func() error
 
+// NewRemoteConnection returns a usable RemoteConnection.
 func NewRemoteConnection(from, to *Peer, tcpAddr string, outbound bool, established bool) *RemoteConnection {
 	return &RemoteConnection{
 		local:         from,
@@ -72,24 +99,39 @@ func NewRemoteConnection(from, to *Peer, tcpAddr string, outbound bool, establis
 	}
 }
 
-func (conn *RemoteConnection) Local() *Peer                           { return conn.local }
-func (conn *RemoteConnection) Remote() *Peer                          { return conn.remote }
-func (conn *RemoteConnection) RemoteTCPAddr() string                  { return conn.remoteTCPAddr }
-func (conn *RemoteConnection) Outbound() bool                         { return conn.outbound }
-func (conn *RemoteConnection) Established() bool                      { return conn.established }
-func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak { return TieBreakTied }
-func (conn *RemoteConnection) Shutdown(error)                         {}
+// Local implements Connection.
+func (conn *RemoteConnection) Local() *Peer { return conn.local }
 
+// Remote implements Connection.
+func (conn *RemoteConnection) Remote() *Peer { return conn.remote }
+
+// RemoteTCPAddr implements Connection.
+func (conn *RemoteConnection) RemoteTCPAddr() string { return conn.remoteTCPAddr }
+
+// Outbound implements Connection.
+func (conn *RemoteConnection) Outbound() bool { return conn.outbound }
+
+// Established implements Connection.
+func (conn *RemoteConnection) Established() bool { return conn.established }
+
+// BreakTie implements Connection.
+func (conn *RemoteConnection) BreakTie(Connection) ConnectionTieBreak { return TieBreakTied }
+
+// Shutdown implements Connection.
+func (conn *RemoteConnection) Shutdown(error) {}
+
+// Log implements Connection.
 func (conn *RemoteConnection) Log(args ...interface{}) {
 	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
 }
 
+// ErrorLog is the same as log. TODO(pb): remove.
 func (conn *RemoteConnection) ErrorLog(args ...interface{}) {
 	log.Errorln(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
 }
 
-// Does not return anything. If the connection is successful, it will
-// end up in the local peer's connections map.
+// StartLocalConnection does not return anything. If the connection is
+// successful, it will end up in the local peer's connections map.
 func StartLocalConnection(connRemote *RemoteConnection, tcpConn *net.TCPConn, router *Router, acceptNewPeer bool) {
 	if connRemote.local != router.Ourself.Peer {
 		log.Fatal("Attempt to create local connection from a peer which is not ourself")
@@ -105,11 +147,13 @@ func StartLocalConnection(connRemote *RemoteConnection, tcpConn *net.TCPConn, ro
 		uid:              randUint64(),
 		actionChan:       actionChan,
 		errorChan:        errorChan,
-		finished:         finished}
+		finished:         finished,
+	}
 	conn.gossipSenders = NewGossipSenders(conn, finished)
 	go conn.run(actionChan, errorChan, finished, acceptNewPeer)
 }
 
+// BreakTie conducts a tiebreaking contest between two connections.
 func (conn *LocalConnection) BreakTie(dupConn Connection) ConnectionTieBreak {
 	dupConnLocal := dupConn.(*LocalConnection)
 	// conn.uid is used as the tie breaker here, in the knowledge that
@@ -118,15 +162,17 @@ func (conn *LocalConnection) BreakTie(dupConn Connection) ConnectionTieBreak {
 		return TieBreakWon
 	} else if dupConnLocal.uid < conn.uid {
 		return TieBreakLost
-	} else {
-		return TieBreakTied
 	}
+	return TieBreakTied
 }
 
+// Established returns true if the connection is established.
+// TODO(pb): data race?
 func (conn *LocalConnection) Established() bool {
 	return conn.established
 }
 
+// SendProtocolMsg implements ProtocolSender.
 func (conn *LocalConnection) SendProtocolMsg(m ProtocolMsg) error {
 	if err := conn.sendProtocolMsg(m); err != nil {
 		conn.Shutdown(err)
@@ -135,6 +181,7 @@ func (conn *LocalConnection) SendProtocolMsg(m ProtocolMsg) error {
 	return nil
 }
 
+// GossipSenders implements GossipConnection.
 func (conn *LocalConnection) GossipSenders() *GossipSenders {
 	return conn.gossipSenders
 }
@@ -146,7 +193,8 @@ func (conn *LocalConnection) GossipSenders() *GossipSenders {
 // do not need locks for reading, and only need write locks for fields
 // read by other processes.
 
-// Non-blocking.
+// Shutdown is non-blocking.
+// TODO(pb): must be?
 func (conn *LocalConnection) Shutdown(err error) {
 	// err should always be a real error, even if only io.EOF
 	if err == nil {
@@ -282,6 +330,7 @@ func (conn *LocalConnection) makeFeatures() map[string]string {
 
 type features map[string]string
 
+// TODO(pb): don't export
 func (features features) MustHave(keys []string) error {
 	for _, key := range keys {
 		if _, ok := features[key]; !ok {
@@ -291,6 +340,7 @@ func (features features) MustHave(keys []string) error {
 	return nil
 }
 
+// TODO(pb): don't export
 func (features features) Get(key string) string {
 	return features[key]
 }
@@ -387,6 +437,7 @@ func (conn *LocalConnection) actorLoop(actionChan <-chan ConnectionAction, error
 			}
 		}
 	}
+
 	return
 }
 
@@ -468,6 +519,9 @@ func (conn *LocalConnection) extendReadDeadline() {
 	conn.TCPConn.SetReadDeadline(time.Now().Add(TCPHeartbeat * 2))
 }
 
+// Untrusted returns true if either we don't trust our remote, or are not
+// trusted by our remote.
+// TODO(pb): does this need to be exported?
 func (conn *LocalConnection) Untrusted() bool {
 	return !conn.TrustRemote || !conn.TrustedByRemote
 }

--- a/deprecate.go
+++ b/deprecate.go
@@ -1,0 +1,14 @@
+package mesh
+
+import (
+	"github.com/weaveworks/weave/common"
+)
+
+// Symbols in this file shall eventually be removed.
+
+var (
+	log        = common.Log
+	checkFatal = common.CheckFatal
+	checkWarn  = common.CheckWarn
+	void       = struct{}{}
+)

--- a/gossip.go
+++ b/gossip.go
@@ -20,7 +20,7 @@ type Gossip interface {
 
 	// GossipBroadcast emits a message to all peers in the mesh.
 	// TODO(pb): rename to Broadcast?
-	GossipBroadcast(update GossipData) error
+	GossipBroadcast(update GossipData)
 }
 
 // Gossiper is the receiving interface.

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -123,7 +123,7 @@ func (c *GossipChannel) relayUnicast(dstPeerName PeerName, buf []byte) (err erro
 	} else if conn, found := c.ourself.ConnectionTo(relayPeerName); !found {
 		err = fmt.Errorf("unable to find connection to relay peer %s", relayPeerName)
 	} else {
-		conn.(ProtocolSender).SendProtocolMsg(ProtocolMsg{ProtocolGossipUnicast, buf})
+		err = conn.(ProtocolSender).SendProtocolMsg(ProtocolMsg{ProtocolGossipUnicast, buf})
 	}
 	return err
 }

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -76,9 +76,7 @@ func (c *GossipChannel) deliverBroadcast(srcName PeerName, _ []byte, dec *gob.De
 	if err != nil || data == nil {
 		return err
 	}
-	if err := c.relayBroadcast(srcName, data); err != nil {
-		c.log(err)
-	}
+	c.relayBroadcast(srcName, data)
 	return nil
 }
 
@@ -103,8 +101,8 @@ func (c *GossipChannel) GossipUnicast(dstPeerName PeerName, msg []byte) error {
 
 // GossipBroadcast implements Gossip, relaying update to all members of the
 // channel.
-func (c *GossipChannel) GossipBroadcast(update GossipData) error {
-	return c.relayBroadcast(c.ourself.Name, update)
+func (c *GossipChannel) GossipBroadcast(update GossipData) {
+	c.relayBroadcast(c.ourself.Name, update)
 }
 
 // Send relays data into the channel topology via random neighbours.
@@ -128,12 +126,11 @@ func (c *GossipChannel) relayUnicast(dstPeerName PeerName, buf []byte) (err erro
 	return err
 }
 
-func (c *GossipChannel) relayBroadcast(srcName PeerName, update GossipData) error {
+func (c *GossipChannel) relayBroadcast(srcName PeerName, update GossipData) {
 	c.routes.EnsureRecalculated()
 	for _, conn := range c.ourself.ConnectionsTo(c.routes.BroadcastAll(srcName)) {
 		c.senderFor(conn).Broadcast(srcName, update)
 	}
-	return nil
 }
 
 func (c *GossipChannel) relay(srcName PeerName, data GossipData) {

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+// GossipChannel is a logical communication channel within a physical mesh.
+// TODO(pb): does this need to be exported?
 type GossipChannel struct {
 	name     string
 	ourself  *LocalPeer
@@ -13,6 +15,9 @@ type GossipChannel struct {
 	gossiper Gossiper
 }
 
+// NewGossipChannel returns a named, usable channel.
+// It delegates receiving duties to the passed Gossiper.
+// TODO(pb): does this need to be exported?
 func NewGossipChannel(channelName string, ourself *LocalPeer, routes *Routes, g Gossiper) *GossipChannel {
 	return &GossipChannel{
 		name:     channelName,
@@ -90,18 +95,24 @@ func (c *GossipChannel) deliver(srcName PeerName, _ []byte, dec *gob.Decoder) er
 	return nil
 }
 
+// GossipUnicast implements Gossip, relaying msg to dst, which must be a
+// member of the channel.
 func (c *GossipChannel) GossipUnicast(dstPeerName PeerName, msg []byte) error {
 	return c.relayUnicast(dstPeerName, GobEncode(c.name, c.ourself.Name, dstPeerName, msg))
 }
 
+// GossipBroadcast implements Gossip, relaying update to all members of the
+// channel.
 func (c *GossipChannel) GossipBroadcast(update GossipData) error {
 	return c.relayBroadcast(c.ourself.Name, update)
 }
 
+// Send relays data into the channel topology via random neighbours.
 func (c *GossipChannel) Send(data GossipData) {
 	c.relay(c.ourself.Name, data)
 }
 
+// SendDown relays data into the channel topology via conn.
 func (c *GossipChannel) SendDown(conn Connection, data GossipData) {
 	c.senderFor(conn).Send(data)
 }
@@ -152,6 +163,8 @@ func (c *GossipChannel) log(args ...interface{}) {
 	log.Println(append(append([]interface{}{}, "[gossip "+c.name+"]:"), args...)...)
 }
 
+// GobEncode gob-encodes each item and returns the resulting byte slice.
+// TODO(pb): does this need to be exported?
 func GobEncode(items ...interface{}) []byte {
 	buf := new(bytes.Buffer)
 	enc := gob.NewEncoder(buf)

--- a/overlay.go
+++ b/overlay.go
@@ -4,6 +4,7 @@ import (
 	"net"
 )
 
+// Overlay yields OverlayConnections.
 type Overlay interface {
 	// Enhance a features map with overlay-related features
 	AddFeaturesTo(map[string]string)
@@ -16,6 +17,7 @@ type Overlay interface {
 	Diagnostics() interface{}
 }
 
+// OverlayConnectionParams are used to set up overlay connections.
 type OverlayConnectionParams struct {
 	RemotePeer *Peer
 
@@ -53,64 +55,65 @@ type OverlayConnectionParams struct {
 	Features map[string]string
 }
 
-// All of the machinery to manage overlay connectivity to a particular
-// peer
+// OverlayConnection describes all of the machinery to manage overlay
+// connectivity to a particular peer.
 type OverlayConnection interface {
 	// Confirm that the connection is really wanted, and so the
 	// Overlay should begin heartbeats etc. to verify the operation of
 	// the overlay connection.
 	Confirm()
 
-	// A channel indicating that the overlay connection is
-	// established, i.e. its operation has been confirmed.
+	// EstablishedChannel returns a channel that will be closed when the
+	// overlay connection is established, i.e. its operation has been
+	// confirmed.
 	EstablishedChannel() <-chan struct{}
 
-	// A channel indicating an error from the overlay connection.  The
-	// overlay connection is not expected to be operational after the
-	// first error, so the channel only needs to buffer a single
+	// ErrorChannel returns a channel that forwards errors from the overlay
+	// connection. The overlay connection is not expected to be operational
+	// after the first error, so the channel only needs to buffer a single
 	// error.
 	ErrorChannel() <-chan error
 
+	// Stop terminates the connection.
 	Stop()
 
-	// Handle a message from the peer.  'tag' exists for
-	// compatibility, and should always be
-	// ProtocolOverlayControlMessage for non-sleeve overlays.
+	// ControlMessage handles a message from the remote peer. 'tag' exists for
+	// compatibility, and should always be ProtocolOverlayControlMessage for
+	// non-sleeve overlays.
 	ControlMessage(tag byte, msg []byte)
 
-	// User facing overlay name
+	// DisplayName returns the user-facing overlay name.
 	DisplayName() string
 }
 
+// NullOverlay implements Overlay and OverlayConnection with no-ops.
 type NullOverlay struct{}
 
-func (NullOverlay) AddFeaturesTo(map[string]string) {
-}
+// AddFeaturesTo implements Overlay.
+func (NullOverlay) AddFeaturesTo(map[string]string) {}
 
+// PrepareConnection implements Overlay.
 func (NullOverlay) PrepareConnection(OverlayConnectionParams) (OverlayConnection, error) {
 	return NullOverlay{}, nil
 }
 
-func (NullOverlay) Diagnostics() interface{} {
-	return nil
-}
-func (NullOverlay) Confirm() {
-}
+// Diagnostics implements Overlay.
+func (NullOverlay) Diagnostics() interface{} { return nil }
 
-func (NullOverlay) EstablishedChannel() <-chan struct{} {
-	return nil
-}
+// Confirm implements OverlayConnection.
+func (NullOverlay) Confirm() {}
 
-func (NullOverlay) ErrorChannel() <-chan error {
-	return nil
-}
+// EstablishedChannel implements OverlayConnection.
+func (NullOverlay) EstablishedChannel() <-chan struct{} { return nil }
 
-func (NullOverlay) Stop() {
-}
+// ErrorChannel implements OverlayConnection.
+func (NullOverlay) ErrorChannel() <-chan error { return nil }
 
-func (NullOverlay) ControlMessage(byte, []byte) {
-}
+// Stop implements OverlayConnection.
+func (NullOverlay) Stop() {}
 
-func (NullOverlay) DisplayName() string {
-	return "null"
-}
+// ControlMessage implements OverlayConnection.
+func (NullOverlay) ControlMessage(byte, []byte) {}
+
+// DisplayName implements OverlayConnection.
+func (NullOverlay) DisplayName() string { return "null" }

--- a/peer_name_hash.go
+++ b/peer_name_hash.go
@@ -1,29 +1,36 @@
 // +build peer_name_hash
 
-// Let peer names be sha256 hashes...of anything (as long as it's
-// unique).
-
 package mesh
+
+// Let peer names be SHA256 hashes of anything, provided they are unique.
 
 import (
 	"crypto/sha256"
 	"encoding/hex"
 )
 
+// PeerName must be globally unique and usable as a map key.
 type PeerName string
 
 const (
+	// PeerNameFlavour is the type of peer names we use.
 	PeerNameFlavour = "hash"
-	NameSize        = sha256.Size >> 1
+	// NameSize is the number of bytes in a peer name.
+	NameSize = sha256.Size >> 1
+	// UnknownPeerName is used as a sentinel value.
 	UnknownPeerName = PeerName("")
 )
 
+// PeerNameFromUserInput parses PeerName from a user-provided string.
+// TODO(pb): does this need to be exported?
 func PeerNameFromUserInput(userInput string) (PeerName, error) {
 	// fixed-length identity
 	nameByteAry := sha256.Sum256([]byte(userInput))
 	return PeerNameFromBin(nameByteAry[:NameSize]), nil
 }
 
+// PeerNameFromString parses PeerName from a generic string.
+// TODO(pb): does this need to be exported?
 func PeerNameFromString(nameStr string) (PeerName, error) {
 	if _, err := hex.DecodeString(nameStr); err != nil {
 		return UnknownPeerName, err
@@ -31,16 +38,20 @@ func PeerNameFromString(nameStr string) (PeerName, error) {
 	return PeerName(nameStr), nil
 }
 
+// PeerNameFromBin parses PeerName from a byte slice.
+// TODO(pb): does this need to be exported?
 func PeerNameFromBin(nameByte []byte) PeerName {
 	return PeerName(hex.EncodeToString(nameByte))
 }
 
+// Bin encodes PeerName as a byte slice.
 func (name PeerName) Bin() []byte {
 	res, err := hex.DecodeString(string(name))
 	checkFatal(err)
 	return res
 }
 
+// String encodes PeerName as a string.
 func (name PeerName) String() string {
 	return string(name)
 }

--- a/peer_name_hash_test.go
+++ b/peer_name_hash_test.go
@@ -1,0 +1,17 @@
+// +build peer_name_hash
+
+package mesh_test
+
+import "testing"
+
+func TestHashPeerNameFromUserInput(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestHashPeerNameFromString(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestHashPeerNameFromBin(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/peer_name_mac.go
+++ b/peer_name_mac.go
@@ -1,9 +1,12 @@
-// The !peer_name_alternative effectively makes this the default,
-// i.e. to choose an alternative, run "go build -tags
-// 'peer_name_alternative peer_name_hash'"
-
 // +build peer_name_mac !peer_name_alternative
 
+package mesh
+
+// The !peer_name_alternative effectively makes this the default,
+// i.e. to choose an alternative, run
+//
+//   go build -tags 'peer_name_alternative peer_name_hash'
+//
 // Let peer names be MACs...
 //
 // MACs need to be unique across our network, or bad things will
@@ -15,28 +18,32 @@
 // name. In particular it doesn't actually have to be the MAC of, say,
 // the network interface the peer is sniffing on.
 
-package mesh
-
 import (
 	"net"
 )
 
-// PeerName is used as a map key. Since net.HardwareAddr isn't
-// suitable for that - it's a slice, and slices can't be map keys - we
-// convert that to/from uint64.
+// PeerName is used as a map key. Since net.HardwareAddr isn't suitable for
+// that - it's a slice, and slices can't be map keys - we convert that to/from
+// uint64.
 type PeerName uint64
 
 const (
+	// PeerNameFlavour is the type of peer names we use.
 	PeerNameFlavour = "mac"
-	NameSize        = 6
+	// NameSize is the number of bytes in a peer name.
+	NameSize = 6
+	// UnknownPeerName is used as a sentinel value.
 	UnknownPeerName = PeerName(0)
 )
 
+// PeerNameFromUserInput parses PeerName from a user-provided string.
+// TODO(pb): does this need to be exported?
 func PeerNameFromUserInput(userInput string) (PeerName, error) {
-	res, err := PeerNameFromString(userInput)
-	return res, err
+	return PeerNameFromString(userInput)
 }
 
+// PeerNameFromString parses PeerName from a generic string.
+// TODO(pb): does this need to be exported?
 func PeerNameFromString(nameStr string) (PeerName, error) {
 	mac, err := net.ParseMAC(nameStr)
 	if err != nil {
@@ -45,14 +52,18 @@ func PeerNameFromString(nameStr string) (PeerName, error) {
 	return PeerName(macint(mac)), nil
 }
 
+// PeerNameFromBin parses PeerName from a byte slice.
+// TODO(pb): does this need to be exported?
 func PeerNameFromBin(nameByte []byte) PeerName {
 	return PeerName(macint(net.HardwareAddr(nameByte)))
 }
 
+// Bin encodes PeerName as a byte slice.
 func (name PeerName) Bin() []byte {
 	return intmac(uint64(name))
 }
 
+// String encodes PeerName as a string.
 func (name PeerName) String() string {
 	return intmac(uint64(name)).String()
 }

--- a/peer_name_mac_test.go
+++ b/peer_name_mac_test.go
@@ -1,0 +1,17 @@
+// +build peer_name_mac !peer_name_alternative
+
+package mesh_test
+
+import "testing"
+
+func TestMacPeerNameFromUserInput(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestMacPeerNameFromString(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestMacPeerNameFromBin(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/peer_test.go
+++ b/peer_test.go
@@ -1,0 +1,11 @@
+package mesh_test
+
+import "testing"
+
+func TestPeerRoutes(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestPeerForEachConnectedPeer(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/protocol_crypto_test.go
+++ b/protocol_crypto_test.go
@@ -1,0 +1,15 @@
+package mesh_test
+
+import "testing"
+
+func TestGobTCPSenderReceiver(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestLengthPrefixTCPSenderReceiver(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestEncryptedTCPSenderReceiver(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/router.go
+++ b/router.go
@@ -163,12 +163,7 @@ func (router *Router) BroadcastTopologyUpdate(update []*Peer) {
 	for _, p := range update {
 		names[p.Name] = void
 	}
-	if err := router.TopologyGossip.GossipBroadcast(&TopologyGossipData{
-		peers: router.Peers,
-		update: names,
-	}); err != nil {
-		log.Errorf("Error broadcasting topology update: %v", err)
-	}
+	router.TopologyGossip.GossipBroadcast(&TopologyGossipData{peers: router.Peers, update: names})
 }
 
 // OnGossipUnicast implements Gossiper, but always returns an error, as a

--- a/router.go
+++ b/router.go
@@ -163,8 +163,12 @@ func (router *Router) BroadcastTopologyUpdate(update []*Peer) {
 	for _, p := range update {
 		names[p.Name] = void
 	}
-	router.TopologyGossip.GossipBroadcast(
-		&TopologyGossipData{peers: router.Peers, update: names})
+	if err := router.TopologyGossip.GossipBroadcast(&TopologyGossipData{
+		peers: router.Peers,
+		update: names,
+	}); err != nil {
+		log.Errorf("Error broadcasting topology update: %v", err)
+	}
 }
 
 // OnGossipUnicast implements Gossiper, but always returns an error, as a

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,23 @@
+package mesh_test
+
+import "testing"
+
+func TestRoutesUnicast(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestRoutesUnicastAll(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestRoutesBroadcast(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestRoutesBroadcastAll(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestRoutesRecalculate(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/surrogate_gossiper.go
+++ b/surrogate_gossiper.go
@@ -1,17 +1,55 @@
 package mesh
 
+// SurrogateGossiper ignores unicasts and relays broadcasts and gossips.
+// TODO(pb): should this be exported?
+type SurrogateGossiper struct{}
+
+var _ Gossiper = &SurrogateGossiper{}
+
+// OnGossipUnicast implements Gossiper.
+func (*SurrogateGossiper) OnGossipUnicast(sender PeerName, msg []byte) error {
+	return nil
+}
+
+// OnGossipBroadcast implements Gossiper.
+func (*SurrogateGossiper) OnGossipBroadcast(_ PeerName, update []byte) (GossipData, error) {
+	return NewSurrogateGossipData(update), nil
+}
+
+// Gossip implements Gossiper.
+func (*SurrogateGossiper) Gossip() GossipData {
+	return nil
+}
+
+// OnGossip implements Gossiper.
+func (*SurrogateGossiper) OnGossip(update []byte) (GossipData, error) {
+	return NewSurrogateGossipData(update), nil
+}
+
+// TODO(pb): remove?
+var (
+	surrogateGossiper SurrogateGossiper
+)
+
+// SurrogateGossipData is a simple in-memory GossipData.
+// TODO(pb): should this be exported?
 type SurrogateGossipData struct {
 	messages [][]byte
 }
 
+var _ GossipData = &SurrogateGossipData{}
+
+// NewSurrogateGossipData returns a new SurrogateGossipData.
 func NewSurrogateGossipData(msg []byte) *SurrogateGossipData {
 	return &SurrogateGossipData{messages: [][]byte{msg}}
 }
 
+// Encode implements GossipData.
 func (d *SurrogateGossipData) Encode() [][]byte {
 	return d.messages
 }
 
+// Merge implements GossipData.
 func (d *SurrogateGossipData) Merge(other GossipData) GossipData {
 	o := other.(*SurrogateGossipData)
 	messages := make([][]byte, 0, len(d.messages)+len(o.messages))
@@ -19,27 +57,3 @@ func (d *SurrogateGossipData) Merge(other GossipData) GossipData {
 	messages = append(messages, o.messages...)
 	return &SurrogateGossipData{messages: messages}
 }
-
-// SurrogateGossiper ignores unicasts and relays broadcasts and gossips.
-
-type SurrogateGossiper struct{}
-
-func (*SurrogateGossiper) OnGossipUnicast(sender PeerName, msg []byte) error {
-	return nil
-}
-
-func (*SurrogateGossiper) OnGossipBroadcast(_ PeerName, update []byte) (GossipData, error) {
-	return NewSurrogateGossipData(update), nil
-}
-
-func (*SurrogateGossiper) Gossip() GossipData {
-	return nil
-}
-
-func (*SurrogateGossiper) OnGossip(update []byte) (GossipData, error) {
-	return NewSurrogateGossipData(update), nil
-}
-
-var (
-	surrogateGossiper SurrogateGossiper
-)

--- a/surrogate_gossiper_test.go
+++ b/surrogate_gossiper_test.go
@@ -1,0 +1,27 @@
+package mesh_test
+
+import "testing"
+
+func TestSurrogateGossiperUnicast(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestSurrogateGossiperBroadcast(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestSurrogateGossiperGossip(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestSurrogateGossiperOnGossip(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestSurrogateGossipDataEncode(t *testing.T) {
+	t.Skip("TODO")
+}
+
+func TestSurrogateGossipDataMerge(t *testing.T) {
+	t.Skip("TODO")
+}

--- a/token_bucket.go
+++ b/token_bucket.go
@@ -4,6 +4,9 @@ import (
 	"time"
 )
 
+// TokenBucket acts as a rate-limiter.
+// It is not safe for concurrent use by multiple goroutines.
+// TODO(pb): should this be exported?
 type TokenBucket struct {
 	capacity             int64         // Maximum capacity of bucket
 	tokenInterval        time.Duration // Token replenishment rate
@@ -11,6 +14,8 @@ type TokenBucket struct {
 	earliestUnspentToken time.Time
 }
 
+// NewTokenBucket returns a bucket containing capacity tokens, refilled at a
+// rate of one token per tokenInterval.
 func NewTokenBucket(capacity int64, tokenInterval time.Duration) *TokenBucket {
 	tb := TokenBucket{
 		capacity:       capacity,
@@ -22,6 +27,8 @@ func NewTokenBucket(capacity int64, tokenInterval time.Duration) *TokenBucket {
 	return &tb
 }
 
+// Wait blocks until there is a token available.
+// Wait is not safe for concurrent use by multiple goroutines.
 func (tb *TokenBucket) Wait() {
 	// If earliest unspent token is in the future, sleep until then
 	time.Sleep(tb.earliestUnspentToken.Sub(time.Now()))

--- a/token_bucket_test.go
+++ b/token_bucket_test.go
@@ -1,0 +1,7 @@
+package mesh_test
+
+import "testing"
+
+func TestTokenBucket(t *testing.T) {
+	t.Skip("TODO")
+}


### PR DESCRIPTION
This PR serves the following purposes:

- Initial code archaeology for @peterbourgon
- Plant some flags for future refactoring
- Properly document exported methods to improve lint scores
- Create test stubs for untested components

There should be no functional changes here.

```
$ for b in master todo-stubs
    git checkout $b >/dev/null 2>&1
    echo $b: (./lint | wc -l)
  end

master:      213
todo-stubs:  0
```