### PR TITLE
Add Host field to router config

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -21,6 +21,7 @@ type peerAddrs map[string]*net.TCPAddr
 type connectionMaker struct {
 	ourself     *localPeer
 	peers       *Peers
+	localAddr   string
 	port        int
 	discovery   bool
 	targets     map[string]*target
@@ -51,13 +52,15 @@ type target struct {
 // relevant candidates.
 type connectionMakerAction func() bool
 
-// newConnectionMaker returns a usable ConnectionMaker, seeded with peers,
-// listening on port. If discovery is true, ConnectionMaker will attempt to
+// newConnectionMaker returns a usable ConnectionMaker, seeded with
+// peers, making outbound connections from localAddr, and listening on
+// port. If discovery is true, ConnectionMaker will attempt to
 // initiate new connections with peers it's not directly connected to.
-func newConnectionMaker(ourself *localPeer, peers *Peers, port int, discovery bool) *connectionMaker {
+func newConnectionMaker(ourself *localPeer, peers *Peers, localAddr string, port int, discovery bool) *connectionMaker {
 	cm := &connectionMaker{
 		ourself:     ourself,
 		peers:       peers,
+		localAddr:   localAddr,
 		port:        port,
 		discovery:   discovery,
 		directPeers: peerAddrs{},
@@ -332,7 +335,7 @@ func (cm *connectionMaker) connectToTargets(validTarget map[string]struct{}, dir
 
 func (cm *connectionMaker) attemptConnection(address string, acceptNewPeer bool) {
 	log.Printf("->[%s] attempting connection", address)
-	if err := cm.ourself.createConnection(address, acceptNewPeer); err != nil {
+	if err := cm.ourself.createConnection(cm.localAddr, address, acceptNewPeer); err != nil {
 		log.Printf("->[%s] error during connection attempt: %v", address, err)
 		cm.connectionAborted(address, err)
 	}

--- a/local_peer.go
+++ b/local_peer.go
@@ -76,17 +76,22 @@ func (peer *localPeer) ConnectionsTo(names []PeerName) []Connection {
 	return conns
 }
 
-// CreateConnection creates a new connection to peerAddr. If acceptNewPeer is
-// false, peerAddr must already be a member of the mesh.
-func (peer *localPeer) createConnection(peerAddr string, acceptNewPeer bool) error {
+// createConnection creates a new connection, originating from
+// localAddr, to peerAddr. If acceptNewPeer is false, peerAddr must
+// already be a member of the mesh.
+func (peer *localPeer) createConnection(localAddr string, peerAddr string, acceptNewPeer bool) error {
 	if err := peer.checkConnectionLimit(); err != nil {
 		return err
 	}
-	tcpAddr, err := net.ResolveTCPAddr("tcp4", peerAddr)
+	localTCPAddr, err := net.ResolveTCPAddr("tcp4", localAddr)
 	if err != nil {
 		return err
 	}
-	tcpConn, err := net.DialTCP("tcp4", nil, tcpAddr)
+	remoteTCPAddr, err := net.ResolveTCPAddr("tcp4", peerAddr)
+	if err != nil {
+		return err
+	}
+	tcpConn, err := net.DialTCP("tcp4", localTCPAddr, remoteTCPAddr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Permit specification of a host IP address to be used for binding the mesh control plane listen socket and as the local address for outbound connections.