### PR TITLE
Example: increment-only counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ _testmain.go
 Makefile
 Dockerfile
 
+examples/increment-only-counter/increment-only-counter
+

--- a/examples/increment-only-counter/README.md
+++ b/examples/increment-only-counter/README.md
@@ -1,0 +1,36 @@
+# Increment-only counter
+
+This example implements an in-memory key-value cache.
+Keys are strings, and values are increment-only counters.
+This is a state-based CRDT, so the write operation is set(key, value).
+
+## Demo
+
+Start several peers on the same host.
+Tell the second and subsequent peers to connect to the first one.
+
+```
+$ ./increment-only-counter -hwaddr 00:00:00:00:00:01 -nickname a -mesh :6001 -http :8001 &
+$ ./increment-only-counter -hwaddr 00:00:00:00:00:02 -nickname b -mesh :6002 -http :8002 -peer 127.0.0.1:6001 &
+$ ./increment-only-counter -hwaddr 00:00:00:00:00:03 -nickname c -mesh :6003 -http :8003 -peer 127.0.0.1:6001 &
+```
+
+Set a value using the HTTP API of any peer.
+
+```
+$ curl -Ss -XPOST "http://localhost:8003/?key=a&value=123"
+set(a, 123) => 123
+```
+
+Get the value from any other peer.
+
+```
+$ curl -Ss -XGET "http://localhost:8001/?key=a"
+get(a) => 123
+```
+
+## Implementation
+
+- [The state object](/examples/increment-only-counter/state.go) implements GossipData.
+- [The peer object](/examples/increment-only-counter/peer.go) implements Gossiper.
+- [The func main](/examples/increment-only-counter/main.go) wires the components together.

--- a/examples/increment-only-counter/main.go
+++ b/examples/increment-only-counter/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/weaveworks/mesh"
+)
+
+func main() {
+	peers := &stringset{}
+	var (
+		httpListen = flag.String("http", ":8080", "HTTP listen address")
+		meshListen = flag.String("mesh", net.JoinHostPort("0.0.0.0", strconv.Itoa(mesh.Port)), "mesh listen address")
+		hwaddr     = flag.String("hwaddr", mustHardwareAddr(), "MAC address, i.e. mesh peer ID")
+		nickname   = flag.String("nickname", mustHostname(), "peer nickname")
+		password   = flag.String("password", "", "password (optional)")
+		channel    = flag.String("channel", "default", "gossip channel name")
+	)
+	flag.Var(peers, "peer", "initial peer (may be repeated)")
+	flag.Parse()
+
+	log.SetPrefix(*nickname + "> ")
+
+	host, portStr, err := net.SplitHostPort(*meshListen)
+	if err != nil {
+		log.Fatalf("mesh address: %s: %v", *meshListen, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		log.Fatalf("mesh address: %s: %v", *meshListen, err)
+	}
+
+	name, err := mesh.PeerNameFromString(*hwaddr)
+	if err != nil {
+		log.Fatalf("%s: %v", *hwaddr, err)
+	}
+
+	router := mesh.NewRouter(mesh.Config{
+		Host:               host,
+		Port:               port,
+		ProtocolMinVersion: mesh.ProtocolMinVersion,
+		Password:           []byte(*password),
+		ConnLimit:          64,
+		PeerDiscovery:      true,
+		TrustedSubnets:     []*net.IPNet{},
+	}, name, *nickname, mesh.NullOverlay{})
+
+	peer := newPeer(log.New(os.Stderr, *nickname+"> ", log.LstdFlags))
+	gossip := router.NewGossip(*channel, peer)
+	peer.register(gossip)
+
+	func() {
+		log.Printf("mesh router starting (%s)", *meshListen)
+		router.Start()
+	}()
+	defer func() {
+		log.Printf("mesh router stopping")
+		router.Stop()
+	}()
+
+	router.ConnectionMaker.InitiateConnections(peers.slice(), true)
+
+	errs := make(chan error, 2)
+
+	go func() {
+		c := make(chan os.Signal)
+		signal.Notify(c, syscall.SIGINT)
+		errs <- fmt.Errorf("%s", <-c)
+	}()
+
+	go func() {
+		log.Printf("HTTP server starting (%s)", *httpListen)
+		http.HandleFunc("/", handle(peer))
+		errs <- http.ListenAndServe(*httpListen, nil)
+	}()
+
+	log.Print(<-errs)
+}
+
+type kv interface {
+	get(key string) (result int, ok bool)
+	set(key string, value int) (result int)
+}
+
+func handle(kv kv) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "GET":
+			key := r.FormValue("key")
+			if key == "" {
+				http.Error(w, "no key specified", http.StatusBadRequest)
+				return
+			}
+			result, ok := kv.get(key)
+			if !ok {
+				http.Error(w, fmt.Sprintf("%s not found", key), http.StatusNotFound)
+				return
+			}
+			fmt.Fprintf(w, "get(%s) => %d\n", key, result)
+
+		case "POST":
+			key := r.FormValue("key")
+			if key == "" {
+				http.Error(w, "no key specified", http.StatusBadRequest)
+				return
+			}
+			valueStr := r.FormValue("value")
+			if valueStr == "" {
+				http.Error(w, "no value specified", http.StatusBadRequest)
+				return
+			}
+			value, err := strconv.Atoi(valueStr)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			result := kv.set(key, value)
+			fmt.Fprintf(w, "set(%s, %d) => %d\n", key, value, result)
+		}
+	}
+}
+
+type stringset map[string]struct{}
+
+func (ss stringset) Set(value string) error {
+	ss[value] = struct{}{}
+	return nil
+}
+
+func (ss stringset) String() string {
+	return strings.Join(ss.slice(), ",")
+}
+
+func (ss stringset) slice() []string {
+	slice := make([]string, 0, len(ss))
+	for k := range ss {
+		slice = append(slice, k)
+	}
+	sort.Strings(slice)
+	return slice
+}
+
+func mustHardwareAddr() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		panic(err)
+	}
+	for _, iface := range ifaces {
+		if s := iface.HardwareAddr.String(); s != "" {
+			return s
+		}
+	}
+	panic("no valid network interfaces")
+}
+
+func mustHostname() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+	return hostname
+}

--- a/examples/increment-only-counter/peer.go
+++ b/examples/increment-only-counter/peer.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/weaveworks/mesh"
+)
+
+// Peer encapsulates state and implements mesh.Gossiper.
+// It should be passed to mesh.Router.NewGossip,
+// and the resulting Gossip registered in turn,
+// before calling mesh.Router.Start.
+type peer struct {
+	st      *state
+	send    mesh.Gossip
+	actions chan<- func()
+	quit    chan struct{}
+	logger  *log.Logger
+}
+
+// peer implements mesh.Gossiper.
+var _ mesh.Gossiper = &peer{}
+
+// Construct a peer with empty state.
+// Be sure to register a channel, later,
+// so we can make outbound communication.
+func newPeer(logger *log.Logger) *peer {
+	actions := make(chan func())
+	p := &peer{
+		st:      newState(),
+		send:    nil, // must .register() later
+		actions: actions,
+		quit:    make(chan struct{}),
+		logger:  logger,
+	}
+	go p.loop(actions)
+	return p
+}
+
+func (p *peer) loop(actions <-chan func()) {
+	for {
+		select {
+		case f := <-actions:
+			f()
+		case <-p.quit:
+			return
+		}
+	}
+}
+
+// register the result of a mesh.Router.NewGossip.
+func (p *peer) register(send mesh.Gossip) {
+	p.actions <- func() { p.send = send }
+}
+
+// Return the current value of the key.
+func (p *peer) get(key string) (result int, ok bool) {
+	c := make(chan struct{})
+	p.actions <- func() {
+		defer close(c)
+		result, ok = p.st.set[key]
+	}
+	<-c
+	return result, ok
+}
+
+// Set key to value, and return the new value.
+// The returned result may be different from the passed value,
+// if the passed value is lower than the existing result.
+func (p *peer) set(key string, value int) (result int) {
+	c := make(chan struct{})
+	p.actions <- func() {
+		defer close(c)
+		st := newState().completeMerge(map[string]int{key: value})
+		data := p.st.Merge(st)
+		if p.send != nil {
+			p.send.GossipBroadcast(st)
+		} else {
+			log.Printf("no sender configured; not broadcasting update right now")
+		}
+		result = data.(*state).set[key]
+	}
+	<-c
+	return result
+}
+
+func (p *peer) stop() {
+	close(p.quit)
+}
+
+// Return a copy of our complete state.
+func (p *peer) Gossip() (complete mesh.GossipData) {
+	complete = p.st.copy()
+	p.logger.Printf("Gossip => complete %v", complete.(*state).set)
+	return complete
+}
+
+// Merge the gossiped data represented by buf into our state.
+// Return the state information that was modified.
+func (p *peer) OnGossip(buf []byte) (delta mesh.GossipData, err error) {
+	var set map[string]int
+	if err := json.Unmarshal(buf, &set); err != nil {
+		return nil, err
+	}
+
+	delta = p.st.deltaMerge(set)
+	if delta == nil {
+		p.logger.Printf("OnGossip %v => delta %v", set, delta)
+	} else {
+		p.logger.Printf("OnGossip %v => delta %v", set, delta.(*state).set)
+	}
+	return delta, nil
+}
+
+// Merge the gossiped data represented by buf into our state.
+// Return our complete resulting state.
+func (p *peer) OnGossipBroadcast(src mesh.PeerName, buf []byte) (complete mesh.GossipData, err error) {
+	var set map[string]int
+	if err := json.Unmarshal(buf, &set); err != nil {
+		return nil, err
+	}
+
+	complete = p.st.completeMerge(set)
+	p.logger.Printf("OnGossipBroadcast %s %v => complete %v", src, set, complete.(*state).set)
+	return complete, nil
+}
+
+// Merge the gossiped data represented by buf into our state.
+func (p *peer) OnGossipUnicast(src mesh.PeerName, buf []byte) error {
+	var set map[string]int
+	if err := json.Unmarshal(buf, &set); err != nil {
+		return err
+	}
+
+	complete := p.st.completeMerge(set)
+	p.logger.Printf("OnGossipUnicast %s %v => complete %v", src, set, complete)
+	return nil
+}

--- a/examples/increment-only-counter/peer_test.go
+++ b/examples/increment-only-counter/peer_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/mesh"
+)
+
+func TestPeerOnGossip(t *testing.T) {
+	for _, testcase := range []struct {
+		initial map[string]int
+		msg     map[string]int
+		want    map[string]int
+	}{
+		{
+			map[string]int{},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1},
+			map[string]int{"a": 0, "b": 2},
+			map[string]int{"b": 2},
+		},
+		{
+			map[string]int{"a": 9},
+			map[string]int{"a": 8},
+			nil,
+		},
+	} {
+		p := newPeer(log.New(ioutil.Discard, "", 0))
+		p.st.completeMerge(testcase.initial)
+		buf, _ := json.Marshal(testcase.msg)
+		delta, err := p.OnGossip(buf)
+		if err != nil {
+			t.Errorf("%v OnGossip %v: %v", testcase.initial, testcase.msg, err)
+			continue
+		}
+		if want := testcase.want; want == nil {
+			if delta != nil {
+				t.Errorf("%v OnGossip %v: want nil, have non-nil", testcase.initial, testcase.msg)
+			}
+		} else {
+			if have := delta.(*state).set; !reflect.DeepEqual(want, have) {
+				t.Errorf("%v OnGossip %v: want %v, have %v", testcase.initial, testcase.msg, want, have)
+			}
+		}
+	}
+}
+
+func TestPeerOnGossipBroadcast(t *testing.T) {
+	for _, testcase := range []struct {
+		initial map[string]int
+		msg     map[string]int
+		want    map[string]int
+	}{
+		{
+			map[string]int{},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1},
+			map[string]int{"a": 0, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 9},
+			map[string]int{"a": 8},
+			map[string]int{"a": 9},
+		},
+	} {
+		p := newPeer(log.New(ioutil.Discard, "", 0))
+		p.st.completeMerge(testcase.initial)
+		buf, _ := json.Marshal(testcase.msg)
+		delta, err := p.OnGossipBroadcast(mesh.UnknownPeerName, buf)
+		if err != nil {
+			t.Errorf("%v OnGossipBroadcast %v: %v", testcase.initial, testcase.msg, err)
+			continue
+		}
+		if want, have := testcase.want, delta.(*state).set; !reflect.DeepEqual(want, have) {
+			t.Errorf("%v OnGossipBroadcast %v: want %v, have %v", testcase.initial, testcase.msg, want, have)
+		}
+	}
+}
+
+func TestPeerOnGossipUnicast(t *testing.T) {
+	for _, testcase := range []struct {
+		initial map[string]int
+		msg     map[string]int
+		want    map[string]int
+	}{
+		{
+			map[string]int{},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1},
+			map[string]int{"a": 0, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 9},
+			map[string]int{"a": 8},
+			map[string]int{"a": 9},
+		},
+	} {
+		p := newPeer(log.New(ioutil.Discard, "", 0))
+		p.st.completeMerge(testcase.initial)
+		buf, _ := json.Marshal(testcase.msg)
+		if err := p.OnGossipUnicast(mesh.UnknownPeerName, buf); err != nil {
+			t.Errorf("%v OnGossipBroadcast %v: %v", testcase.initial, testcase.msg, err)
+			continue
+		}
+		if want, have := testcase.want, p.st.set; !reflect.DeepEqual(want, have) {
+			t.Errorf("%v OnGossipBroadcast %v: want %v, have %v", testcase.initial, testcase.msg, want, have)
+		}
+	}
+}

--- a/examples/increment-only-counter/state.go
+++ b/examples/increment-only-counter/state.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/weaveworks/mesh"
+)
+
+// An increment-only counter for an arbitrary keyspace.
+type state struct {
+	mtx sync.RWMutex
+	set map[string]int
+}
+
+// state implements GossipData.
+var _ mesh.GossipData = &state{}
+
+// Construct an empty state object, ready to receive updates.
+// This is suitable to use at program start.
+// Other peers will populate us with data.
+func newState() *state {
+	return &state{
+		set: map[string]int{},
+	}
+}
+
+// Encode serializes our complete state to a slice of byte-slices.
+// In this simple example, we use a single JSON-encoded buffer.
+func (st *state) Encode() [][]byte {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	buf, err := json.Marshal(st.set)
+	if err != nil {
+		panic(err)
+	}
+	return [][]byte{buf}
+}
+
+// Merge merges the other GossipData into this one,
+// and returns our resulting, complete state.
+func (st *state) Merge(other mesh.GossipData) (complete mesh.GossipData) {
+	return st.completeMerge(other.(*state).copy().set)
+}
+
+func (st *state) copy() *state {
+	st.mtx.RLock()
+	defer st.mtx.RUnlock()
+	return &state{
+		set: st.set,
+	}
+}
+
+// Merge the set into our state, abiding increment-only semantics.
+// Return any key/values that have been mutated, or nil if nothing changed.
+func (st *state) deltaMerge(set map[string]int) (delta mesh.GossipData) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+
+	for k, v := range set {
+		if v <= st.set[k] {
+			delete(set, k)
+			continue
+		}
+		st.set[k] = v
+	}
+
+	if len(set) <= 0 {
+		return nil // per OnGossip requirements
+	}
+	return &state{
+		set: set, // all remaining elements were novel to us
+	}
+}
+
+// Merge the set into our state, abiding increment-only semantics.
+// Return our resulting, complete state.
+func (st *state) completeMerge(set map[string]int) (complete mesh.GossipData) {
+	st.mtx.Lock()
+	defer st.mtx.Unlock()
+
+	for k, v := range set {
+		if v > st.set[k] {
+			st.set[k] = v
+		}
+	}
+
+	return &state{
+		set: st.set, // n.b. can't .copy() due to lock contention
+	}
+}

--- a/examples/increment-only-counter/state_test.go
+++ b/examples/increment-only-counter/state_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestStateConvergence(t *testing.T) {
+	var (
+		seed  = time.Now().UnixNano()
+		r     = rand.New(rand.NewSource(seed))
+		nKeys = r.Intn(100) + 100
+		nVals = r.Intn(10) + 5
+		ops   = []map[string]int{}
+		final = map[string]int{}
+	)
+
+	// For each key, generate nVals values.
+	// Remember the largest: it should "stick".
+
+	for i := 0; i < nKeys; i++ {
+		key := strconv.Itoa(i)
+		maxval := 0
+		for j := 0; j < nVals; j++ {
+			val := r.Intn(nVals * 100)
+			if val > maxval {
+				maxval = val
+			}
+			ops = append(ops, map[string]int{key: int(val)})
+		}
+		final[key] = maxval
+	}
+
+	// No matter what order the ops are applied,
+	// the end result should be the same:
+	// each key should have its maxval.
+
+	for i := 0; i < 10; i++ {
+		st := newState()
+		var debug bytes.Buffer
+
+		merge := func(index int) {
+			st.Merge(newState().completeMerge(ops[index]))
+			fmt.Fprintf(&debug, "Merge %v\n", ops[index])
+		}
+
+		// Random order + some duplication
+		for _, index := range r.Perm(len(ops)) {
+			merge(index)
+			if r.Intn(100) < 10 {
+				merge(index)
+			}
+		}
+
+		for key, want := range final {
+			if have := st.set[key]; want != have {
+				t.Logf("seed=%d, nKeys=%d, nVals=%d", seed, nKeys, nVals)
+				t.Logf("%s", debug.String())
+				t.Fatalf("%q: want %d, have %d", key, want, have)
+			}
+		}
+	}
+}
+
+func TestStateCompleteMerge(t *testing.T) {
+	for _, testcase := range []struct {
+		initial map[string]int
+		merge   map[string]int
+		want    map[string]int
+	}{
+		{
+			map[string]int{},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"c": 3},
+			map[string]int{"a": 1, "b": 2, "c": 3},
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 0, "b": 3},
+			map[string]int{"a": 1, "b": 3},
+		},
+	} {
+		st := newState().completeMerge(testcase.initial).(*state).completeMerge(testcase.merge).(*state)
+		if want, have := testcase.want, st.set; !reflect.DeepEqual(want, have) {
+			t.Errorf("%v completeMerge %v: want %v, have %v", testcase.initial, testcase.merge, want, have)
+		}
+	}
+}
+
+func TestStateDeltaMerge(t *testing.T) {
+	for _, testcase := range []struct {
+		initial map[string]int
+		merge   map[string]int
+		want    map[string]int
+	}{
+		{
+			map[string]int{},
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"a": 1, "b": 2},
+			nil,
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"c": 3},
+			map[string]int{"c": 3},
+		},
+		{
+			map[string]int{"a": 1, "b": 2},
+			map[string]int{"b": 3},
+			map[string]int{"b": 3},
+		},
+	} {
+		delta := newState().completeMerge(testcase.initial).(*state).deltaMerge(testcase.merge)
+		if want := testcase.want; want == nil {
+			if delta != nil {
+				t.Errorf("%v deltaMerge %v: want nil, have non-nil", testcase.initial, testcase.merge)
+			}
+		} else {
+			if have := delta.(*state).set; !reflect.DeepEqual(want, have) {
+				t.Errorf("%v deltaMerge %v: want %v, have %v", testcase.initial, testcase.merge, want, have)
+			}
+		}
+	}
+}


### PR DESCRIPTION
An increment-only counter shared among peers, as a strawman to test and improve upon the user-facing API.

Suggested action items from this experiment:

- Rename mesh.Config to mesh.RouterConfig.
- Modify mesh.NewRouter to place mesh.RouterConfig last, and ensure sensible defaults if fields aren't specified.
- Create simplified mesh.NewSimpleRouter constructor, with fewer options.
- As a user, I have no way of knowing what type of string I should pass to PeerNameFrom{String,UserInput}, except a priori. So, I propose to remove non-MAC-based PeerName, and amend MAC PeerName documentation to make it clear it's not strictly necessary to use a MAC address.
- Move InitializeConnections to the Router object directly, so we can eliminate connectionMaker from the exported API
- In the router, port should be a string, just as everywhere else in the standard library.
- Improve documentation and provide examples of what is an Overlay and why I should care. (Will investigate this in the next example.)
- mesh should use a passed logger rather than the global logger