### PR TITLE
Fix retval semantics for Gossiper

### DIFF
--- a/examples/increment-only-counter/peer_test.go
+++ b/examples/increment-only-counter/peer_test.go
@@ -33,7 +33,7 @@ func TestPeerOnGossip(t *testing.T) {
 		},
 	} {
 		p := newPeer(log.New(ioutil.Discard, "", 0))
-		p.st.completeMerge(testcase.initial)
+		p.st.mergeComplete(testcase.initial)
 		buf, _ := json.Marshal(testcase.msg)
 		delta, err := p.OnGossip(buf)
 		if err != nil {
@@ -66,16 +66,16 @@ func TestPeerOnGossipBroadcast(t *testing.T) {
 		{
 			map[string]int{"a": 1},
 			map[string]int{"a": 0, "b": 2},
-			map[string]int{"a": 1, "b": 2},
+			map[string]int{"b": 2},
 		},
 		{
 			map[string]int{"a": 9},
 			map[string]int{"a": 8},
-			map[string]int{"a": 9},
+			map[string]int{}, // OnGossipBroadcast returns received, which should never be nil
 		},
 	} {
 		p := newPeer(log.New(ioutil.Discard, "", 0))
-		p.st.completeMerge(testcase.initial)
+		p.st.mergeComplete(testcase.initial)
 		buf, _ := json.Marshal(testcase.msg)
 		delta, err := p.OnGossipBroadcast(mesh.UnknownPeerName, buf)
 		if err != nil {
@@ -111,7 +111,7 @@ func TestPeerOnGossipUnicast(t *testing.T) {
 		},
 	} {
 		p := newPeer(log.New(ioutil.Discard, "", 0))
-		p.st.completeMerge(testcase.initial)
+		p.st.mergeComplete(testcase.initial)
 		buf, _ := json.Marshal(testcase.msg)
 		if err := p.OnGossipUnicast(mesh.UnknownPeerName, buf); err != nil {
 			t.Errorf("%v OnGossipBroadcast %v: %v", testcase.initial, testcase.msg, err)

--- a/gossip.go
+++ b/gossip.go
@@ -3,41 +3,49 @@ package mesh
 import "sync"
 
 // Gossip is the sending interface.
+//
 // TODO(pb): rename to e.g. Sender
 type Gossip interface {
 	// GossipUnicast emits a single message to a peer in the mesh.
+	//
 	// TODO(pb): rename to Unicast?
 	//
 	// Unicast takes []byte instead of GossipData because "to date there has
 	// been no compelling reason [in practice] to do merging on unicast."
 	// But there may be some motivation to have unicast Mergeable; see
 	// https://github.com/weaveworks/weave/issues/1764
+	//
 	// TODO(pb): for uniformity of interface, rather take GossipData?
 	GossipUnicast(dst PeerName, msg []byte) error
 
 	// GossipBroadcast emits a message to all peers in the mesh.
+	//
 	// TODO(pb): rename to Broadcast?
 	GossipBroadcast(update GossipData)
 }
 
 // Gossiper is the receiving interface.
+//
 // TODO(pb): rename to e.g. Receiver
 type Gossiper interface {
 	// OnGossipUnicast merges received data into state.
+	//
 	// TODO(pb): rename to e.g. OnUnicast
 	OnGossipUnicast(src PeerName, msg []byte) error
 
 	// OnGossipBroadcast merges received data into state and returns a
-	// representation of the received data, for further propagation.
+	// representation of the received data (typically a delta) for further
+	// propagation.
+	//
 	// TODO(pb): rename to e.g. OnBroadcast
-	OnGossipBroadcast(src PeerName, update []byte) (GossipData, error)
+	OnGossipBroadcast(src PeerName, update []byte) (received GossipData, err error)
 
 	// Gossip returns the state of everything we know; gets called periodically.
-	Gossip() GossipData
+	Gossip() (complete GossipData)
 
 	// OnGossip merges received data into state and returns "everything new
 	// I've just learnt", or nil if nothing in the received data was new.
-	OnGossip(msg []byte) (GossipData, error)
+	OnGossip(msg []byte) (delta GossipData, err error)
 }
 
 // GossipData is a merge-able dataset.
@@ -47,6 +55,7 @@ type GossipData interface {
 	Encode() [][]byte
 
 	// Merge combines another GossipData into this one and returns the result.
+	//
 	// TODO(pb): does it need to be leave the original unmodified?
 	Merge(GossipData) GossipData
 }

--- a/peer.go
+++ b/peer.go
@@ -27,6 +27,14 @@ type peerSummary struct {
 	HasShortID bool
 }
 
+// PeerDescription collects information about peers that is useful to clients.
+type PeerDescription struct {
+	Name           PeerName
+	NickName       string
+	Self           bool
+	NumConnections int
+}
+
 type connectionSet map[Connection]struct{}
 
 func newPeerFromSummary(summary peerSummary) *Peer {

--- a/peers.go
+++ b/peers.go
@@ -66,6 +66,22 @@ func newPeers(ourself *localPeer) *Peers {
 	return peers
 }
 
+// Descriptions returns descriptions for all known peers.
+func (peers *Peers) Descriptions() []PeerDescription {
+	peers.RLock()
+	defer peers.RUnlock()
+	descriptions := make([]PeerDescription, 0, len(peers.byName))
+	for _, peer := range peers.byName {
+		descriptions = append(descriptions, PeerDescription{
+			Name:           peer.Name,
+			NickName:       peer.peerSummary.NickName,
+			Self:           peer.Name == peers.ourself.Name,
+			NumConnections: len(peer.connections),
+		})
+	}
+	return descriptions
+}
+
 // OnGC adds a new function to be set of functions that will be executed on
 // all subsequent GC runs, receiving the GC'd peer.
 func (peers *Peers) OnGC(callback func(*Peer)) {


### PR DESCRIPTION
- OnGossipBroadcast shall return the received data
- OnGossip shall return a computed delta
- Gossip shall receive the complete data

Often OnGossip and OnGossipBroadcast will return the same thing, but not always: it depends on the particulars of the underlying GossipData.

Also, update increment-only-counter example to reflect these changes.