### PR TITLE
Allow callers of Targets() to exclude 'retry-never' peers

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -135,14 +135,20 @@ func (cm *connectionMaker) ForgetConnections(peers []string) {
 	}
 }
 
-// Targets takes a snapshot of the active targets (direct peers).
+// Targets takes a snapshot of the targets (direct peers),
+// either just the ones we are still trying, or all of them.
 // Note these are the same things that InitiateConnections and ForgetConnections talks about,
 // but a method to retrieve 'Connections' would obviously return the current connections.
-func (cm *connectionMaker) Targets() []string {
+func (cm *connectionMaker) Targets(activeOnly bool) []string {
 	resultChan := make(chan []string, 0)
 	cm.actionChan <- func() bool {
 		var slice []string
 		for peer := range cm.directPeers {
+			if activeOnly {
+				if target, ok := cm.targets[peer]; ok && target.tryAfter.IsZero() {
+					continue
+				}
+			}
 			slice = append(slice, peer)
 		}
 		resultChan <- slice

--- a/status.go
+++ b/status.go
@@ -40,7 +40,7 @@ func NewStatus(router *Router) *Status {
 		UnicastRoutes:      makeUnicastRouteStatusSlice(router.Routes),
 		BroadcastRoutes:    makeBroadcastRouteStatusSlice(router.Routes),
 		Connections:        makeLocalConnectionStatusSlice(router.ConnectionMaker),
-		Targets:            router.ConnectionMaker.Targets(),
+		Targets:            router.ConnectionMaker.Targets(false),
 		OverlayDiagnostics: router.Overlay.Diagnostics(),
 		TrustedSubnets:     makeTrustedSubnetsSlice(router.TrustedSubnets),
 	}


### PR DESCRIPTION
Required for https://github.com/weaveworks/weave/pull/2070