### PR TITLE
shrink Connection interface

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -19,12 +19,11 @@ type Connection interface {
 	isEstablished() bool
 }
 
-type LConnection interface {
+type ourConnection interface {
 	Connection
 
-	breakTie(LConnection) connectionTieBreak
+	breakTie(ourConnection) connectionTieBreak
 	shutdown(error)
-
 	log(args ...interface{})
 }
 
@@ -106,7 +105,7 @@ func (conn *LocalConnection) log(args ...interface{}) {
 	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
 }
 
-func (conn *LocalConnection) breakTie(dupConn LConnection) connectionTieBreak {
+func (conn *LocalConnection) breakTie(dupConn ourConnection) connectionTieBreak {
 	dupConnLocal := dupConn.(*LocalConnection)
 	// conn.uid is used as the tie breaker here, in the knowledge that
 	// both sides will make the same decision.

--- a/connection.go
+++ b/connection.go
@@ -14,11 +14,17 @@ type Connection interface {
 	Remote() *Peer
 
 	getLocal() *Peer
-	breakTie(Connection) connectionTieBreak
 	remoteTCPAddress() string
 	isOutbound() bool
 	isEstablished() bool
+}
+
+type LConnection interface {
+	Connection
+
+	breakTie(LConnection) connectionTieBreak
 	shutdown(error)
+
 	log(args ...interface{})
 }
 
@@ -46,19 +52,11 @@ func (conn *remoteConnection) Remote() *Peer { return conn.remote }
 
 func (conn *remoteConnection) getLocal() *Peer { return conn.local }
 
-func (conn *remoteConnection) breakTie(Connection) connectionTieBreak { return tieBreakTied }
-
 func (conn *remoteConnection) remoteTCPAddress() string { return conn.remoteTCPAddr }
 
 func (conn *remoteConnection) isOutbound() bool { return conn.outbound }
 
 func (conn *remoteConnection) isEstablished() bool { return conn.established }
-
-func (conn *remoteConnection) shutdown(error) {}
-
-func (conn *remoteConnection) log(args ...interface{}) {
-	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
-}
 
 // LocalConnection is the local (our) side of a connection.
 // It implements ProtocolSender, and manages per-channel GossipSenders.
@@ -104,7 +102,11 @@ func startLocalConnection(connRemote *remoteConnection, tcpConn *net.TCPConn, ro
 	go conn.run(actionChan, errorChan, finished, acceptNewPeer)
 }
 
-func (conn *LocalConnection) breakTie(dupConn Connection) connectionTieBreak {
+func (conn *LocalConnection) log(args ...interface{}) {
+	log.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
+}
+
+func (conn *LocalConnection) breakTie(dupConn LConnection) connectionTieBreak {
 	dupConnLocal := dupConn.(*LocalConnection)
 	// conn.uid is used as the tie breaker here, in the knowledge that
 	// both sides will make the same decision.

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -27,7 +27,7 @@ func newTestRouter(name string) *Router {
 	return router
 }
 
-func (conn *mockGossipConnection) breakTie(dupConn LConnection) connectionTieBreak {
+func (conn *mockGossipConnection) breakTie(dupConn ourConnection) connectionTieBreak {
 	return tieBreakTied
 }
 
@@ -88,7 +88,7 @@ func (router *Router) DeleteTestGossipConnection(r *Router) {
 	toName := r.Ourself.Peer.Name
 	conn, _ := router.Ourself.ConnectionTo(toName)
 	router.Peers.dereference(conn.Remote())
-	router.Ourself.handleDeleteConnection(conn.(LConnection))
+	router.Ourself.handleDeleteConnection(conn.(ourConnection))
 }
 
 // Create a Peer representing the receiver router, with connections to

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -27,6 +27,17 @@ func newTestRouter(name string) *Router {
 	return router
 }
 
+func (conn *mockGossipConnection) breakTie(dupConn LConnection) connectionTieBreak {
+	return tieBreakTied
+}
+
+func (conn *mockGossipConnection) shutdown(err error) {
+}
+
+func (conn *mockGossipConnection) log(args ...interface{}) {
+	fmt.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
+}
+
 func (conn *mockGossipConnection) SendProtocolMsg(pm protocolMsg) error {
 	<-conn.start
 	return conn.dest.handleGossip(pm.tag, pm.msg)
@@ -77,7 +88,7 @@ func (router *Router) DeleteTestGossipConnection(r *Router) {
 	toName := r.Ourself.Peer.Name
 	conn, _ := router.Ourself.ConnectionTo(toName)
 	router.Peers.dereference(conn.Remote())
-	router.Ourself.handleDeleteConnection(conn)
+	router.Ourself.handleDeleteConnection(conn.(LConnection))
 }
 
 // Create a Peer representing the receiver router, with connections to

--- a/local_peer.go
+++ b/local_peer.go
@@ -103,7 +103,7 @@ func (peer *localPeer) createConnection(localAddr string, peerAddr string, accep
 // ACTOR client API
 
 // Synchronous.
-func (peer *localPeer) doAddConnection(conn *LocalConnection) error {
+func (peer *localPeer) doAddConnection(conn LConnection) error {
 	resultChan := make(chan error)
 	peer.actionChan <- func() {
 		resultChan <- peer.handleAddConnection(conn)
@@ -112,14 +112,14 @@ func (peer *localPeer) doAddConnection(conn *LocalConnection) error {
 }
 
 // Asynchronous.
-func (peer *localPeer) doConnectionEstablished(conn *LocalConnection) {
+func (peer *localPeer) doConnectionEstablished(conn LConnection) {
 	peer.actionChan <- func() {
 		peer.handleConnectionEstablished(conn)
 	}
 }
 
 // Synchronous.
-func (peer *localPeer) doDeleteConnection(conn *LocalConnection) {
+func (peer *localPeer) doDeleteConnection(conn LConnection) {
 	resultChan := make(chan interface{})
 	peer.actionChan <- func() {
 		peer.handleDeleteConnection(conn)
@@ -148,7 +148,7 @@ func (peer *localPeer) actorLoop(actionChan <-chan localPeerAction) {
 	}
 }
 
-func (peer *localPeer) handleAddConnection(conn Connection) error {
+func (peer *localPeer) handleAddConnection(conn LConnection) error {
 	if peer.Peer != conn.getLocal() {
 		log.Fatal("Attempt made to add connection to peer where peer is not the source of connection")
 	}
@@ -162,16 +162,17 @@ func (peer *localPeer) handleAddConnection(conn Connection) error {
 		if dupConn == conn {
 			return nil
 		}
-		switch conn.breakTie(dupConn) {
+		dupLConn := dupConn.(LConnection)
+		switch conn.breakTie(dupLConn) {
 		case tieBreakWon:
-			dupConn.shutdown(dupErr)
-			peer.handleDeleteConnection(dupConn)
+			dupLConn.shutdown(dupErr)
+			peer.handleDeleteConnection(dupLConn)
 		case tieBreakLost:
 			return dupErr
 		case tieBreakTied:
 			// oh good grief. Sod it, just kill both of them.
-			dupConn.shutdown(dupErr)
-			peer.handleDeleteConnection(dupConn)
+			dupLConn.shutdown(dupErr)
+			peer.handleDeleteConnection(dupLConn)
 			return dupErr
 		}
 	}
@@ -193,7 +194,7 @@ func (peer *localPeer) handleAddConnection(conn Connection) error {
 	return nil
 }
 
-func (peer *localPeer) handleConnectionEstablished(conn Connection) {
+func (peer *localPeer) handleConnectionEstablished(conn LConnection) {
 	if peer.Peer != conn.getLocal() {
 		log.Fatal("Peer informed of active connection where peer is not the source of connection")
 	}
@@ -208,7 +209,7 @@ func (peer *localPeer) handleConnectionEstablished(conn Connection) {
 	peer.broadcastPeerUpdate()
 }
 
-func (peer *localPeer) handleDeleteConnection(conn Connection) {
+func (peer *localPeer) handleDeleteConnection(conn LConnection) {
 	if peer.Peer != conn.getLocal() {
 		log.Fatal("Attempt made to delete connection from peer where peer is not the source of connection")
 	}


### PR DESCRIPTION
RemoteConnection represents information about connections that another peer has. As such it does not need tie breaking, logging or shutdown.

For testing we need mock `LocalConnections`, so we introduce an interface, imaginatively named `LConnection`, which both the real and mock `LocalConnections` implement.

`LConnection` should be renamed to something better.