### PR TITLE
etcd no longer uses rewritten import paths

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,5 @@
 test:
   pre:
+    - rm -rf $GOPATH/src/github.com/coreos/etcd/vendor # https://github.com/coreos/etcd/issues/4913
     - ./lint
 

--- a/metcd/ctrl.go
+++ b/metcd/ctrl.go
@@ -7,9 +7,9 @@ import (
 	"net"
 	"time"
 
-	wackycontext "github.com/coreos/etcd/Godeps/_workspace/src/golang.org/x/net/context"
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"golang.org/x/net/context"
 
 	"github.com/weaveworks/mesh/meshconn"
 )
@@ -155,7 +155,7 @@ func (c *ctrl) driveRaft() {
 			}
 
 		case msg := <-c.incomingc:
-			c.node.Step(wackycontext.TODO(), msg)
+			c.node.Step(context.TODO(), msg)
 
 		case id := <-c.unreachablec:
 			c.node.ReportUnreachable(id)
@@ -184,7 +184,7 @@ func (c *ctrl) driveProposals(cancel <-chan struct{}) {
 				c.proposalc = nil
 				continue
 			}
-			c.node.Propose(wackycontext.TODO(), data)
+			c.node.Propose(context.TODO(), data)
 
 		case cc, ok := <-c.confchangec:
 			if !ok {
@@ -193,7 +193,7 @@ func (c *ctrl) driveProposals(cancel <-chan struct{}) {
 				continue
 			}
 			c.logger.Printf("ctrl: ProposeConfChange %s %x", cc.Type, cc.NodeID)
-			c.node.ProposeConfChange(wackycontext.TODO(), cc)
+			c.node.ProposeConfChange(context.TODO(), cc)
 
 		case <-cancel:
 			return

--- a/metcd/server.go
+++ b/metcd/server.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"time"
 
-	wackygrpc "github.com/coreos/etcd/Godeps/_workspace/src/google.golang.org/grpc"
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/coreos/etcd/raft/raftpb"
+	"google.golang.org/grpc"
 
 	"github.com/weaveworks/mesh"
 	"github.com/weaveworks/mesh/meshconn"
@@ -26,8 +26,8 @@ type Server interface {
 }
 
 // GRPCServer converts a metcd.Server to a *grpc.Server.
-func GRPCServer(s Server, options ...wackygrpc.ServerOption) *wackygrpc.Server {
-	srv := wackygrpc.NewServer(options...)
+func GRPCServer(s Server, options ...grpc.ServerOption) *grpc.Server {
+	srv := grpc.NewServer(options...)
 	//etcdserverpb.RegisterAuthServer(srv, s)
 	//etcdserverpb.RegisterClusterServer(srv, s)
 	etcdserverpb.RegisterKVServer(srv, s)


### PR DESCRIPTION
This means we can drop the wackycontext, wackygrpc, etc. import names. Unfortunately, etcd accomplishes this feat by leveraging the vendor dir, which is viral, i.e. anything that imports coreos/etcd must have its own vendor dir AND must flatten transitive dependencies from dependent packages into that base vendor dir.

See https://groups.google.com/forum/#!topic/golang-nuts/AnMr9NL6dtc