### PR TITLE
Create and use Logger interface

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -2,7 +2,6 @@ package mesh
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
 	"time"
@@ -28,7 +27,7 @@ type connectionMaker struct {
 	connections map[Connection]struct{}
 	directPeers peerAddrs
 	actionChan  chan<- connectionMakerAction
-	logger      *log.Logger
+	logger      Logger
 }
 
 // TargetState describes the connection state of a remote target.
@@ -58,7 +57,7 @@ type connectionMakerAction func() bool
 // peers, making outbound connections from localAddr, and listening on
 // port. If discovery is true, ConnectionMaker will attempt to
 // initiate new connections with peers it's not directly connected to.
-func newConnectionMaker(ourself *localPeer, peers *Peers, localAddr string, port int, discovery bool, logger *log.Logger) *connectionMaker {
+func newConnectionMaker(ourself *localPeer, peers *Peers, localAddr string, port int, discovery bool, logger Logger) *connectionMaker {
 	actionChan := make(chan connectionMakerAction, ChannelSize)
 	cm := &connectionMaker{
 		ourself:     ourself,

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"log"
 )
 
 // gossipChannel is a logical communication channel within a physical mesh.
@@ -13,12 +12,12 @@ type gossipChannel struct {
 	ourself  *localPeer
 	routes   *routes
 	gossiper Gossiper
-	logger   *log.Logger
+	logger   Logger
 }
 
 // newGossipChannel returns a named, usable channel.
 // It delegates receiving duties to the passed Gossiper.
-func newGossipChannel(channelName string, ourself *localPeer, r *routes, g Gossiper, logger *log.Logger) *gossipChannel {
+func newGossipChannel(channelName string, ourself *localPeer, r *routes, g Gossiper, logger Logger) *gossipChannel {
 	return &gossipChannel{
 		name:     channelName,
 		ourself:  ourself,
@@ -41,7 +40,7 @@ func (c *gossipChannel) deliverUnicast(srcName PeerName, origPayload []byte, dec
 		return c.gossiper.OnGossipUnicast(srcName, payload)
 	}
 	if err := c.relayUnicast(destName, origPayload); err != nil {
-		c.log(err)
+		c.logf("%v", err)
 	}
 	return nil
 }
@@ -135,8 +134,9 @@ func (c *gossipChannel) makeBroadcastMsg(srcName PeerName, msg []byte) protocolM
 	return protocolMsg{ProtocolGossipBroadcast, gobEncode(c.name, srcName, msg)}
 }
 
-func (c *gossipChannel) log(args ...interface{}) {
-	c.logger.Println(append(append([]interface{}{}, "[gossip "+c.name+"]:"), args...)...)
+func (c *gossipChannel) logf(format string, args ...interface{}) {
+	format = "[gossip " + c.name + "]: " + format
+	c.logger.Printf(format, args...)
 }
 
 // GobEncode gob-encodes each item and returns the resulting byte slice.

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -36,8 +36,12 @@ func (conn *mockGossipConnection) breakTie(dupConn ourConnection) connectionTieB
 func (conn *mockGossipConnection) shutdown(err error) {
 }
 
-func (conn *mockGossipConnection) log(args ...interface{}) {
-	fmt.Println(append(append([]interface{}{}, fmt.Sprintf("->[%s|%s]:", conn.remoteTCPAddr, conn.remote)), args...)...)
+func (conn *mockGossipConnection) logf(format string, args ...interface{}) {
+	format = "->[" + conn.remoteTCPAddr + "|" + conn.remote.String() + "]: " + format
+	if len(format) == 0 || format[len(format)-1] != '\n' {
+		format += "\n"
+	}
+	fmt.Printf(format, args...)
 }
 
 func (conn *mockGossipConnection) SendProtocolMsg(pm protocolMsg) error {

--- a/local_peer.go
+++ b/local_peer.go
@@ -3,7 +3,6 @@ package mesh
 import (
 	"encoding/gob"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"time"
@@ -79,7 +78,7 @@ func (peer *localPeer) ConnectionsTo(names []PeerName) []Connection {
 // createConnection creates a new connection, originating from
 // localAddr, to peerAddr. If acceptNewPeer is false, peerAddr must
 // already be a member of the mesh.
-func (peer *localPeer) createConnection(localAddr string, peerAddr string, acceptNewPeer bool, logger *log.Logger) error {
+func (peer *localPeer) createConnection(localAddr string, peerAddr string, acceptNewPeer bool, logger Logger) error {
 	if err := peer.checkConnectionLimit(); err != nil {
 		return err
 	}
@@ -183,12 +182,12 @@ func (peer *localPeer) handleAddConnection(conn ourConnection, isRestartedPeer b
 	peer.addConnection(conn)
 	switch {
 	case isRestartedPeer:
-		conn.log("connection added (restarted peer)")
+		conn.logf("connection added (restarted peer)")
 		peer.router.sendAllGossipDown(conn)
 	case isConnectedPeer:
-		conn.log("connection added")
+		conn.logf("connection added")
 	default:
-		conn.log("connection added (new peer)")
+		conn.logf("connection added (new peer)")
 		peer.router.sendAllGossipDown(conn)
 	}
 
@@ -207,7 +206,7 @@ func (peer *localPeer) handleConnectionEstablished(conn ourConnection) {
 		return
 	}
 	peer.connectionEstablished(conn)
-	conn.log("connection fully established")
+	conn.logf("connection fully established")
 
 	peer.router.Routes.recalculate()
 	peer.broadcastPeerUpdate()
@@ -225,7 +224,7 @@ func (peer *localPeer) handleDeleteConnection(conn ourConnection) {
 		return
 	}
 	peer.deleteConnection(conn)
-	conn.log("connection deleted")
+	conn.logf("connection deleted")
 	// Must do garbage collection first to ensure we don't send out an
 	// update with unreachable peers (can cause looping)
 	peer.router.Peers.GarbageCollect()

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,24 @@
+package mesh
+
+import "log"
+
+// Logger is a simple interface used by mesh to do logging.
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+// NewStdlibLogger wraps a stdlib log.Logger.
+// If logger is nil, the default stdlib logger is used.
+func NewStdlibLogger(logger *log.Logger) Logger {
+	return stdlibLogger{logger}
+}
+
+type stdlibLogger struct{ logger *log.Logger }
+
+func (l stdlibLogger) Printf(format string, args ...interface{}) {
+	if l.logger == nil {
+		log.Printf(format, args...)
+	} else {
+		l.logger.Printf(format, args...)
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,26 @@
+package mesh
+
+import (
+	"bytes"
+	"log"
+	"testing"
+)
+
+func TestStdlibLoggerNil(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	NewStdlibLogger(nil).Printf("hello %s", "world")
+	if want, have := "hello world\n", buf.String(); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}
+
+func TestStdlibLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "> ", 0)
+	NewStdlibLogger(logger).Printf("123 %d", 456)
+	if want, have := "> 123 456\n", buf.String(); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}


### PR DESCRIPTION
Also, provide stdlib log.Logger adapters, for the lazy.

I decided the clarity of a single-method interface outweighs the convenience of having both Printf and Println style methods, especially as all users of the package will need to bring their own implementation.
As a consequence I refactored the two `log(args ...interface{})` helper methods to `logf(format string, args ...interface{})` and changed the callsites. Output should be equivalent.