### PR TITLE
Expose and restore indirect peers

### DIFF
--- a/_metcd/metcdsrv/main.go
+++ b/_metcd/metcdsrv/main.go
@@ -95,7 +95,8 @@ func main() {
 		router.Stop()
 	}()
 
-	router.ConnectionMaker.InitiateConnections(peers.slice(), true)
+	indirectPeers := []string{}
+	router.ConnectionMaker.InitiateConnections(peers.slice(), indirectPeers, true)
 
 	terminatec := make(chan struct{})
 	terminatedc := make(chan error)

--- a/examples/increment-only-counter/main.go
+++ b/examples/increment-only-counter/main.go
@@ -69,7 +69,8 @@ func main() {
 		router.Stop()
 	}()
 
-	router.ConnectionMaker.InitiateConnections(peers.slice(), true)
+	indirectPeers := []string{}
+	router.ConnectionMaker.InitiateConnections(peers.slice(), indirectPeers, true)
 
 	errs := make(chan error)
 	go func() {

--- a/status.go
+++ b/status.go
@@ -42,7 +42,7 @@ func NewStatus(router *Router) *Status {
 		BroadcastRoutes:    makeBroadcastRouteStatusSlice(router.Routes),
 		Connections:        makeLocalConnectionStatusSlice(router.ConnectionMaker),
 		TerminationCount:   router.ConnectionMaker.terminationCount,
-		Targets:            router.ConnectionMaker.Targets(false),
+		Targets:            makeTargets(router.ConnectionMaker),
 		OverlayDiagnostics: router.Overlay.Diagnostics(),
 		TrustedSubnets:     makeTrustedSubnetsSlice(router.TrustedSubnets),
 	}
@@ -211,6 +211,12 @@ func makeLocalConnectionStatusSlice(cm *connectionMaker) []LocalConnectionStatus
 		return false
 	}
 	return <-resultChan
+}
+
+// makeTargets makes a list of direct peers
+func makeTargets(cm *connectionMaker) []string {
+	direct, _ := cm.Targets(false)
+	return direct
 }
 
 // makeTrustedSubnetsSlice makes a human-readable copy of the trustedSubnets.


### PR DESCRIPTION
In order to implement weaveworks/weave#2187 we need a way to expose and restore 'indirect peers' - targets that have been added via peer discovery instead of `InitiateConnections`.

weaveworks/weave#2317 implements the changes in the router that depend on this modification.

This is pretty grotty, and really only meant as a strawman with the hope someone else can think of a cleaner way. Some possibilities:
1. Have additional methods specifically to extract and restore indirect peers (meh)
2. Modify `InitiateConnections` and `Targets` so that they take/return a slice of a new struct which has a type field (e.g. direct or indirect) instead of string
3. Have some kind of memento API that takes/returns an opaque `interface{}` blob that can be saved and restored by an external agent (this might complicate matters if the router ever has to do a schema upgrade of the datastore)
4. Inject the `ConnectionMaker` with some kind of interface that it uses at appropriate points to a) get a set of direct/indirect peers (e.g. in `newConnectionMaker`) and b) notify when they have changed (e.g. on `InitiateConnections`/`ForgetConnections` or when new targets are added through discovery)

Thoughts?
