### PR TITLE
Detect peer name collisions

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -344,6 +344,9 @@ func (conn *LocalConnection) registerRemote(remote *Peer, acceptNewPeer bool) er
 		}
 	}
 
+	if remote.Name == conn.local.Name && remote.UID != conn.local.UID {
+		return &peerNameCollisionError{conn.local, remote}
+	}
 	if conn.remote == conn.local {
 		return errConnectToSelf
 	}
@@ -474,6 +477,14 @@ const (
 )
 
 var errConnectToSelf = fmt.Errorf("cannot connect to ourself")
+
+type peerNameCollisionError struct {
+	local, remote *Peer
+}
+
+func (err *peerNameCollisionError) Error() string {
+	return fmt.Sprintf("local %q and remote %q peer names collision", err.local, err.remote)
+}
 
 // The actor closure used by LocalConnection. If an action returns an error,
 // it will terminate the actor loop, which terminates the connection in turn.

--- a/connection_maker.go
+++ b/connection_maker.go
@@ -194,8 +194,9 @@ func (cm *connectionMaker) connectionTerminated(conn Connection, err error) {
 			target := cm.targets[conn.remoteTCPAddress()]
 			target.state = targetWaiting
 			target.lastError = err
+			_, peerNameCollision := err.(*peerNameCollisionError)
 			switch {
-			case err == errConnectToSelf:
+			case peerNameCollision || err == errConnectToSelf:
 				target.nextTryNever()
 			case time.Now().After(target.tryAfter.Add(resetAfter)):
 				target.nextTryNow()


### PR DESCRIPTION
This PR adds a machinery for detecting `Peer` names collision during the handshake. In the case of the collision, we log the error and close the connection without trying to reestablish it.