### PR TITLE
Disable metcd tests on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Build the code with the usual
 
 Assuming you've fetched dependencies as above,
 
-`go test ./...`
+`go test $(go list -f '{{.ImportPath}}' ./... | grep -v metcd)`
 
 ### Dependencies
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,5 @@
 test:
   pre:
     - ./lint
-
+  override:
+    - go test -v -race $(go list -f '{{.ImportPath}}' ./... | grep -v metcd)


### PR DESCRIPTION
Alternatively, we could use the `// +build ignore` constraint, but it would require adding the constraint to non-test modules of the `metcd` package as well.