### PR TITLE
Recompute targets immediately after a 'Forget'

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -133,7 +133,7 @@ func (cm *connectionMaker) ForgetConnections(peers []string) {
 		for _, peer := range peers {
 			delete(cm.directPeers, peer)
 		}
-		return false
+		return true
 	}
 }
 


### PR DESCRIPTION
To address the issue seen at https://github.com/weaveworks/weave/issues/2472