### PR TITLE
Fix check for activeOnly targets to include port number

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -145,9 +145,9 @@ func (cm *connectionMaker) Targets(activeOnly bool) []string {
 	resultChan := make(chan []string, 0)
 	cm.actionChan <- func() bool {
 		var slice []string
-		for peer := range cm.directPeers {
+		for peer, addr := range cm.directPeers {
 			if activeOnly {
-				if target, ok := cm.targets[peer]; ok && target.tryAfter.IsZero() {
+				if target, ok := cm.targets[cm.completeAddr(*addr)]; ok && target.tryAfter.IsZero() {
 					continue
 				}
 			}


### PR DESCRIPTION
The entries in the directPeers list can either be like "1.2.3.4" or "1.2.3.4:9999", and in the former case we would not find it in the targets map.