### PR TITLE
Detect empty peer hostname

### DIFF
--- a/connection_maker.go
+++ b/connection_maker.go
@@ -90,8 +90,8 @@ func (cm *connectionMaker) InitiateConnections(peers []string, replace bool) []e
 			host = peer
 			port = "0" // we use that as an indication that "no port was supplied"
 		}
-		if !isAlnum(port) {
-			errors = append(errors, fmt.Errorf("invalid peer name %q, should just be host[:port]", peer))
+		if host == "" || !isAlnum(port) {
+			errors = append(errors, fmt.Errorf("invalid peer name %q, should be host[:port]", peer))
 		} else if addr, err := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%s", host, port)); err != nil {
 			errors = append(errors, err)
 		} else {


### PR DESCRIPTION
In a case of an empty host, a peer tries to connect to itself which eventually results in a panic.