### PR TITLE
always use the connectionMaker supplied remote address

### DIFF
--- a/local_peer.go
+++ b/local_peer.go
@@ -94,7 +94,7 @@ func (peer *localPeer) createConnection(localAddr string, peerAddr string, accep
 	if err != nil {
 		return err
 	}
-	connRemote := newRemoteConnection(peer.Peer, nil, tcpConn.RemoteAddr().String(), true, false)
+	connRemote := newRemoteConnection(peer.Peer, nil, peerAddr, true, false)
 	startLocalConnection(connRemote, tcpConn, peer.router, acceptNewPeer, logger)
 	return nil
 }


### PR DESCRIPTION
The connectionMaker does bookkeeping based on the (string representation of) the remote address. It is therefore important that we use that exact same address in remoteConnection.remoteTCPAddr, since otherwise connection lifecycle events such as termination will not find a corresponding address in the connectionMaker's target map, and panic as a result.

Fixes #59.