### PR TITLE
Add display attributes into LocalConnectionStatus

### DIFF
--- a/overlay.go
+++ b/overlay.go
@@ -82,8 +82,9 @@ type OverlayConnection interface {
 	// non-sleeve overlays.
 	ControlMessage(tag byte, msg []byte)
 
-	// DisplayName returns the user-facing overlay name.
-	DisplayName() string
+	// Attrs returns the user-facing overlay name plus any other
+	// data that users may wish to check or monitor
+	Attrs() map[string]interface{}
 }
 
 // NullOverlay implements Overlay and OverlayConnection with no-ops.
@@ -115,5 +116,5 @@ func (NullOverlay) Stop() {}
 // ControlMessage implements OverlayConnection.
 func (NullOverlay) ControlMessage(byte, []byte) {}
 
-// DisplayName implements OverlayConnection.
-func (NullOverlay) DisplayName() string { return "null" }
+// Attrs implements OverlayConnection.
+func (NullOverlay) Attrs() map[string]interface{} { return nil }


### PR DESCRIPTION
"Display attributes" is some extra data that the overlay wishes to communicate to humans or monitoring systems.

For https://github.com/weaveworks/weave/issues/2663