### PR TITLE
Correct missing checkFatal function

### DIFF
--- a/peer_name_hash.go
+++ b/peer_name_hash.go
@@ -43,10 +43,12 @@ func PeerNameFromBin(nameByte []byte) PeerName {
 	return PeerName(hex.EncodeToString(nameByte))
 }
 
-// Bin encodes PeerName as a byte slice.
-func (name PeerName) Bin() []byte {
+// bytes encodes PeerName as a byte slice.
+func (name PeerName) bytes() []byte {
 	res, err := hex.DecodeString(string(name))
-	checkFatal(err)
+	if err != nil {
+		panic("unable to decode name to bytes: " + name)
+	}
 	return res
 }
 

--- a/peer_name_mac.go
+++ b/peer_name_mac.go
@@ -82,7 +82,7 @@ func PeerNameFromBin(nameByte []byte) PeerName {
 	return PeerName(macint(net.HardwareAddr(nameByte)))
 }
 
-// Bin encodes PeerName as a byte slice.
+// bytes encodes PeerName as a byte slice.
 func (name PeerName) bytes() []byte {
 	return intmac(uint64(name))
 }


### PR DESCRIPTION
For the case when using peer_name_hash, the checkFatal function is not
defined; replace with a panic.