### PR TITLE
Add 'encrypted' flag to connection attributes

### DIFF
--- a/status.go
+++ b/status.go
@@ -176,6 +176,7 @@ func makeLocalConnectionStatusSlice(cm *connectionMaker) []LocalConnectionStatus
 			if lc.router.usingPassword() {
 				if lc.untrusted() {
 					info = fmt.Sprintf("%-11v %v", "encrypted", info)
+					attrs["encrypted"] = true
 				} else {
 					info = fmt.Sprintf("%-11v %v", "unencrypted", info)
 				}


### PR DESCRIPTION
So calling code can find this out without parsing the text