### PR TITLE
Status: report actual min protocol version

### DIFF
--- a/status.go
+++ b/status.go
@@ -30,7 +30,7 @@ type Status struct {
 func NewStatus(router *Router) *Status {
 	return &Status{
 		Protocol:           Protocol,
-		ProtocolMinVersion: ProtocolMinVersion,
+		ProtocolMinVersion: int(router.ProtocolMinVersion),
 		ProtocolMaxVersion: ProtocolMaxVersion,
 		Encryption:         router.usingPassword(),
 		PeerDiscovery:      router.PeerDiscovery,


### PR DESCRIPTION
Hi!
Just a minor thing, but when getting the status of weave, it always reports `Protocol: weave 1..2`, which isn't particularly useful...