### PR TITLE
serialize broadcast topology updates and coalesce updates

### DIFF
--- a/gossip_test.go
+++ b/gossip_test.go
@@ -70,7 +70,12 @@ func sendPendingGossip(routers ...*Router) {
 
 func sendPendingTopologyUpdates(routers ...*Router) {
 	for _, router := range routers {
-		router.Ourself.broadcastPendingTopologyUpdates()
+		router.Ourself.Lock()
+		pendingUpdate := router.Ourself.pendingTopologyUpdate
+		router.Ourself.Unlock()
+		if pendingUpdate {
+			router.Ourself.broadcastPendingTopologyUpdates()
+		}
 	}
 }
 

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -68,6 +68,12 @@ func sendPendingGossip(routers ...*Router) {
 	}
 }
 
+func sendPendingTopologyUpdates(routers ...*Router) {
+	for _, router := range routers {
+		router.Ourself.broadcastPendingTopologyUpdates()
+	}
+}
+
 func addTestGossipConnection(r1, r2 *Router) {
 	c1 := r1.newTestGossipConnection(r2)
 	c2 := r2.newTestGossipConnection(r1)
@@ -121,6 +127,7 @@ func checkTopology(t *testing.T, router *Router, wantedPeers ...*Peer) {
 }
 
 func flushAndCheckTopology(t *testing.T, routers []*Router, wantedPeers ...*Peer) {
+	sendPendingTopologyUpdates(routers...)
 	sendPendingGossip(routers...)
 	for _, r := range routers {
 		checkTopology(t, r, wantedPeers...)
@@ -155,6 +162,7 @@ func TestGossipTopology(t *testing.T) {
 
 	// Drop the connection from 1 to 3
 	r1.DeleteTestGossipConnection(r3)
+	sendPendingTopologyUpdates(routers...)
 	sendPendingGossip(r1, r2, r3)
 	checkTopology(t, r1, r1.tp(r2), r2.tp(r1))
 	checkTopology(t, r2, r1.tp(r2), r2.tp(r1))

--- a/local_peer.go
+++ b/local_peer.go
@@ -165,7 +165,6 @@ func (peer *localPeer) actorLoop(actionChan <-chan localPeerAction) {
 }
 
 func (peer *localPeer) broadcastPendingTopologyUpdates() {
-	peer.router.Routes.recalculate()
 	peer.Lock()
 	gossipData := peer.topologyUpdates
 	peer.topologyUpdates = make(peerNameSet)
@@ -218,6 +217,7 @@ func (peer *localPeer) handleAddConnection(conn ourConnection, isRestartedPeer b
 		conn.logf("connection added (new peer)")
 		peer.router.sendAllGossipDown(conn)
 	}
+	peer.router.Routes.recalculate()
 	peer.broadcastPeerUpdate(conn.Remote())
 
 	return nil
@@ -233,6 +233,8 @@ func (peer *localPeer) handleConnectionEstablished(conn ourConnection) {
 	}
 	peer.connectionEstablished(conn)
 	conn.logf("connection fully established")
+
+	peer.router.Routes.recalculate()
 	peer.broadcastPeerUpdate()
 }
 
@@ -252,6 +254,7 @@ func (peer *localPeer) handleDeleteConnection(conn ourConnection) {
 	// Must do garbage collection first to ensure we don't send out an
 	// update with unreachable peers (can cause looping)
 	peer.router.Peers.GarbageCollect()
+	peer.router.Routes.recalculate()
 	peer.broadcastPeerUpdate()
 }
 

--- a/router.go
+++ b/router.go
@@ -229,18 +229,10 @@ func (router *Router) sendPendingGossip() bool {
 	return sentSomething
 }
 
-// BroadcastTopologyUpdate is invoked whenever there is one or more changes to the mesh
-// topology, and broadcasts the new set of peers to the mesh after coalescing updates.
-func (router *Router) broadcastTopologyUpdate(updates ...[]*Peer) {
-	var gossipData GossipData
-	gossipData = &topologyGossipData{peers: router.Peers, update: nil}
-	for _, update := range updates {
-		names := make(peerNameSet)
-		for _, p := range update {
-			names[p.Name] = struct{}{}
-		}
-		gossipData = gossipData.Merge(&topologyGossipData{peers: router.Peers, update: names})
-	}
+// BroadcastTopologyUpdate is invoked whenever there is a change to the mesh
+// topology, and broadcasts the new set of peers to the mesh.
+func (router *Router) broadcastTopologyUpdate(update peerNameSet) {
+	gossipData := &topologyGossipData{peers: router.Peers, update: update}
 	router.topologyGossip.GossipBroadcast(gossipData)
 }
 


### PR DESCRIPTION
This PR is an attempt to address high topology updates gossip's that can result in certain use-cases.

- minimizes the concurrent topology gossip broadcast updates
- coalesce the topology updates when possible before sending gossip broadcast

Fixes #116