### PR TITLE
add GossiperMaker, GetGossip(), and UTs

### DIFF
--- a/router.go
+++ b/router.go
@@ -41,6 +41,11 @@ type Config struct {
 	GossipInterval     *time.Duration
 }
 
+// GossiperMaker is an interface to create a Gossiper instance
+type GossiperMaker interface {
+	MakeGossiper(channelName string, router *Router) (Gossiper, error)
+}
+
 // Router manages communication between this peer and the rest of the mesh.
 // Router implements Gossiper.
 type Router struct {
@@ -50,6 +55,7 @@ type Router struct {
 	Peers           *Peers
 	Routes          *routes
 	ConnectionMaker *connectionMaker
+	GossiperMaker   GossiperMaker
 	gossipLock      sync.RWMutex
 	gossipChannels  gossipChannels
 	topologyGossip  Gossip
@@ -144,6 +150,13 @@ func (router *Router) NewGossip(channelName string, g Gossiper) (Gossip, error) 
 	return channel, nil
 }
 
+// GetGossip returns a GossipChannel from the router, or nil if the channel has not been seen/created
+func (router *Router) GetGossip(channelName string) Gossip {
+	router.gossipLock.Lock()
+	defer router.gossipLock.Unlock()
+	return router.gossipChannels[channelName]
+}
+
 func (router *Router) gossipChannel(channelName string) *gossipChannel {
 	router.gossipLock.RLock()
 	channel, found := router.gossipChannels[channelName]
@@ -156,7 +169,23 @@ func (router *Router) gossipChannel(channelName string) *gossipChannel {
 	if channel, found = router.gossipChannels[channelName]; found {
 		return channel
 	}
-	channel = newGossipChannel(channelName, router.Ourself, router.Routes, &surrogateGossiper{router: router}, router.logger)
+	// unknown channel - do we have a GossiperMaker?
+	var gossiper Gossiper
+	if router.GossiperMaker != nil {
+		// use the GossiperMaker to make the surrogate channel
+		g, err := router.GossiperMaker.MakeGossiper(channelName, router)
+		if err != nil {
+			router.logger.Printf("unable to create gossiper, falling back to surrogateGossiper: %s", err.Error())
+		} else {
+			router.logger.Printf("created custom surrogate gossiper")
+			gossiper = g
+		}
+	}
+	if gossiper == nil {
+		// default surrogate channel
+		gossiper = &surrogateGossiper{router: router}
+	}
+	channel = newGossipChannel(channelName, router.Ourself, router.Routes, gossiper, router.logger)
 	channel.logf("created surrogate channel")
 	router.gossipChannels[channelName] = channel
 	return channel


### PR DESCRIPTION
This PR adds support for custom surrogate Gossiper implementations, as well as the ability to access surrogate Gossip channels.

If a GossiperMaker is not set, or the assigned GossiperMaker returns nil, the default surrogate implementation will be used for that channel.

This change will allow mesh clients to dynamically provision Gossipers for channels instead of defining them all up-front.  An example use case would be to use channels as dynamic "namespaces" for data feeds.  The data in the feeds could all be the same, or the channel name could indicate what type of data is in the feed.  The GossiperMaker could assign different Gossipers to each channel as they are discovered.  These channels would be retrievable and usable with the new `GetGossip()` method on the router.

```
~/Development/workspace/git/forks/mesh master
❯ go build

~/Development/workspace/git/forks/mesh master
❯ go test
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|01:00:00:01:00:00(nick)]: connection added (new peer)
->[|01:00:00:01:00:00(nick)]: connection fully established
->[|03:00:00:03:00:00(nick)]: connection added (new peer)
->[|03:00:00:03:00:00(nick)]: connection fully established
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|01:00:00:01:00:00(nick)]: connection added
->[|01:00:00:01:00:00(nick)]: connection fully established
->[|03:00:00:03:00:00(nick)]: connection added
->[|03:00:00:03:00:00(nick)]: connection fully established
->[|03:00:00:03:00:00(nick)]: connection deleted
->[|03:00:00:03:00:00(nick)]: connection deleted
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|01:00:00:01:00:00(nick)]: connection added (new peer)
->[|01:00:00:01:00:00(nick)]: connection fully established
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|03:00:00:03:00:00(nick)]: connection added (new peer)
->[|03:00:00:03:00:00(nick)]: connection fully established
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|01:00:00:01:00:00(nick)]: connection added (new peer)
->[|01:00:00:01:00:00(nick)]: connection fully established
->[|02:00:00:02:00:00(nick)]: connection added (new peer)
->[|02:00:00:02:00:00(nick)]: connection fully established
->[|03:00:00:03:00:00(nick)]: connection added (new peer)
->[|03:00:00:03:00:00(nick)]: connection fully established
2019/09/23 08:36:29 test gossiper created!
PASS
ok  	_/Users/britterm/Development/workspace/git/forks/mesh	0.172s
```