### PR TITLE
relay received topology updates to random neighbours instead of broadcast to all peers

### DIFF
--- a/gossip.go
+++ b/gossip.go
@@ -22,6 +22,9 @@ type Gossip interface {
 	//
 	// TODO(pb): rename to Broadcast?
 	GossipBroadcast(update GossipData)
+
+	// GossipRandomNeighbours emits a message to random neighbour peers in the mesh.
+	GossipRandomNeighbours(update GossipData)
 }
 
 // Gossiper is the receiving interface.

--- a/gossip.go
+++ b/gossip.go
@@ -23,8 +23,8 @@ type Gossip interface {
 	// TODO(pb): rename to Broadcast?
 	GossipBroadcast(update GossipData)
 
-	// GossipRandomNeighbours emits a message to random neighbour peers in the mesh.
-	GossipRandomNeighbours(update GossipData)
+	// GossipNeighbourSubset emits a message to subset of neighbour peers in the mesh.
+	GossipNeighbourSubset(update GossipData)
 }
 
 // Gossiper is the receiving interface.

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -83,9 +83,9 @@ func (c *gossipChannel) GossipBroadcast(update GossipData) {
 	c.relayBroadcast(c.ourself.Name, update)
 }
 
-// GossipRandomNeighbours implements Gossip, relaying update to random members of the
+// GossipNeighbourSubset implements Gossip, relaying update to subset of members of the
 // channel.
-func (c *gossipChannel) GossipRandomNeighbours(update GossipData) {
+func (c *gossipChannel) GossipNeighbourSubset(update GossipData) {
 	c.relay(c.ourself.Name, update)
 }
 

--- a/gossip_channel.go
+++ b/gossip_channel.go
@@ -83,6 +83,12 @@ func (c *gossipChannel) GossipBroadcast(update GossipData) {
 	c.relayBroadcast(c.ourself.Name, update)
 }
 
+// GossipRandomNeighbours implements Gossip, relaying update to random members of the
+// channel.
+func (c *gossipChannel) GossipRandomNeighbours(update GossipData) {
+	c.relay(c.ourself.Name, update)
+}
+
 // Send relays data into the channel topology via random neighbours.
 func (c *gossipChannel) Send(data GossipData) {
 	c.relay(c.ourself.Name, data)

--- a/router.go
+++ b/router.go
@@ -233,7 +233,7 @@ func (router *Router) sendPendingGossip() bool {
 // topology, and broadcasts the new set of peers to the mesh.
 func (router *Router) broadcastTopologyUpdate(update peerNameSet) {
 	gossipData := &topologyGossipData{peers: router.Peers, update: update}
-	router.topologyGossip.GossipBroadcast(gossipData)
+	router.topologyGossip.GossipRandomNeighbours(&topologyGossipData{peers: router.Peers, update: names})
 }
 
 // OnGossipUnicast implements Gossiper, but always returns an error, as a

--- a/router.go
+++ b/router.go
@@ -233,7 +233,7 @@ func (router *Router) sendPendingGossip() bool {
 // topology, and broadcasts the new set of peers to the mesh.
 func (router *Router) broadcastTopologyUpdate(update peerNameSet) {
 	gossipData := &topologyGossipData{peers: router.Peers, update: update}
-	router.topologyGossip.GossipRandomNeighbours(&topologyGossipData{peers: router.Peers, update: names})
+	router.topologyGossip.GossipNeighbourSubset(gossipData)
 }
 
 // OnGossipUnicast implements Gossiper, but always returns an error, as a


### PR DESCRIPTION
for relay received topology updates use relay to random neighbours instead of broadcast to all the peers

address the issue #116

- in fully connected topology broadcast is not necessary as each peer learns the topology when connection from peer gets established to self
- in non-fully connected topolgy relay to random neighbour is less effective compared to broadcast but eventully topology gossip data will be synced 


